### PR TITLE
ECOPROJECT-2292: Don't show 'Add source' button if we don't have any sources

### DIFF
--- a/apps/demo/src/migration-wizard/steps/connect/ConnectStep.tsx
+++ b/apps/demo/src/migration-wizard/steps/connect/ConnectStep.tsx
@@ -32,6 +32,7 @@ export const ConnectStep: React.FC = () => {
   const toggleDiscoverySourceSetupModal = useCallback((): void => {
     setShouldShowDiscoverySetupModal((lastState) => !lastState);
   }, []);
+  const hasSources = discoverySourcesContext.sources.length > 0;
 
   return (
     <Stack hasGutter>
@@ -104,14 +105,16 @@ export const ConnectStep: React.FC = () => {
         </Panel>
       </StackItem>
       <StackItem>
-        <Button
-          variant="secondary"
-          onClick={toggleDiscoverySourceSetupModal}
-          style={{ marginTop: "1rem" }}
-          icon={<PlusCircleIcon color={blueColor.value} />}
-        >
-          Add source
-        </Button>
+        {hasSources && (
+          <Button
+            variant="secondary"
+            onClick={toggleDiscoverySourceSetupModal}
+            style={{ marginTop: "1rem" }}
+            icon={<PlusCircleIcon color={blueColor.value} />}
+          >
+            Add source
+          </Button>
+        )}
         {shouldShowDiscoverySourceSetupModal && (
           <DiscoverySourceSetupModal
             isOpen={shouldShowDiscoverySourceSetupModal}


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-2292

Don't show 'Add source' button if we don't have any sources

![image](https://github.com/user-attachments/assets/bde29a92-72da-4ee7-834e-967fb7b3ea67)

Only show the button when we have 1 or more sources:

![image](https://github.com/user-attachments/assets/54a36b96-810b-4aaa-9c8c-514d38922516)
