### PR TITLE
Fix the ssh key validation

### DIFF
--- a/apps/demo/src/migration-wizard/steps/connect/sources-table/empty-state/DiscoverySourceSetupModal.tsx
+++ b/apps/demo/src/migration-wizard/steps/connect/sources-table/empty-state/DiscoverySourceSetupModal.tsx
@@ -40,8 +40,15 @@ export const sshPublicKeyValidationSchema = Yup.string().test(
   },
 );
 
+export interface DiscoverySourceSetupModalProps {
+  isOpen?: boolean;
+  isDisabled?: boolean;
+  onClose: () => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+}
+
 // Your component
-export const DiscoverySourceSetupModal: React.FC<DiscoverySourceSetupModal.Props> = (props) => {
+export const DiscoverySourceSetupModal: React.FC<DiscoverySourceSetupModalProps> = (props) => {
   const { isOpen = false, isDisabled = false, onClose, onSubmit } = props;
 
   const [sshKey, setSshKey] = useState("");


### PR DESCRIPTION
The component is referencing its own Props type. To fix this, wen need to define the DiscoverySourceSetupModalProps interface/type separately before the component.