### PR TITLE
ECOPROJECT-2281: expose migration-planner-ui version in the devtool

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -20,6 +20,7 @@
     "@patternfly/react-icons": "^5.4.0",
     "@patternfly/react-table": "^5.4.0",
     "@redhat-cloud-services/frontend-components": "^4.2.13",
+    "dotenv": "^16.4.5",
     "humanize-plus": "^1.8.2",
     "lodash": "^4.17.21",
     "prop-types": "^15.8.1",

--- a/apps/demo/src/common/version.ts
+++ b/apps/demo/src/common/version.ts
@@ -1,0 +1,10 @@
+import buildManifest from 'demo/package.json';
+
+/**
+ * The function returns the build-time generated version.
+ * It can be overriden via the MIGRATION_PLANNER_UI_VERSION environment variable.
+ */
+export const getMigrationPlannerUiVersion = () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-return
+    return process.env.MIGRATION_PLANNER_UI_VERSION || buildManifest.version;
+  };

--- a/apps/demo/src/components/AppPage.tsx
+++ b/apps/demo/src/components/AppPage.tsx
@@ -14,6 +14,7 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from "@redhat-cloud-services/frontend-components/PageHeader";
+import { getMigrationPlannerUiVersion } from "#/common/version";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace AppPage {
@@ -40,6 +41,9 @@ export const AppPage: React.FC<React.PropsWithChildren<AppPage.Props>> = (
               </BreadcrumbItem>
             ))}
           </Breadcrumb>
+          <div data-testid="migration-planner-ui-version" hidden>
+            {getMigrationPlannerUiVersion()}
+          </div>
         </PageBreadcrumb>
         <PageHeader>
           <PageHeaderTitle title={title} />

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tsconfigPaths from "vite-tsconfig-paths";
+import dotenv from 'dotenv';
 
 // https://vitejs.dev/config/
 export default defineConfig((_env) => {
   return {
+    define: {
+      'process.env': dotenv.config().parsed
+    },
     plugins: [tsconfigPaths(), react()],
     server: {
       proxy: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2511,6 +2511,7 @@ __metadata:
     "@patternfly/react-table": "npm:^5.4.0"
     "@redhat-cloud-services/frontend-components": "npm:^4.2.13"
     "@types/humanize-plus": "npm:^1"
+    dotenv: "npm:^16.4.5"
     humanize-plus: "npm:^1.8.2"
     lodash: "npm:^4.17.21"
     prop-types: "npm:^15.8.1"
@@ -2576,6 +2577,13 @@ __metadata:
     domelementtype: "npm:^2.3.0"
     domhandler: "npm:^5.0.3"
   checksum: 10c0/342d64cf4d07b8a0573fb51e0a6312a88fb520c7fefd751870bf72fa5fc0f2e0cb9a3958a573610b1d608c6e2a69b8e9b4b40f0bfb8f87a71bce4f180cca1887
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.4.5":
+  version: 16.4.5
+  resolution: "dotenv@npm:16.4.5"
+  checksum: 10c0/48d92870076832af0418b13acd6e5a5a3e83bb00df690d9812e94b24aff62b88ade955ac99a05501305b8dc8f1b0ee7638b18493deb6fe93d680e5220936292f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR add the UI version to the devtool in order to allow the user (or for dev and automation) to get the version