### PR TITLE
ECOPROJECT-2399: Disable login button if user don't want to share data

### DIFF
--- a/apps/agent/src/login-form/LoginForm.tsx
+++ b/apps/agent/src/login-form/LoginForm.tsx
@@ -174,6 +174,8 @@ export const LoginForm: React.FC<LoginForm.Props> = (props) => {
               name="isDataSharingAllowed"
               label="I agree to share aggregated data about my environment with Red Hat."
               aria-label="Share aggregated data"
+              onChange={(_event,checked)=>vm.handleChangeDataSharingAllowed(checked)}
+              isChecked={vm.isDataSharingChecked}
             />
           </FormGroup>
           
@@ -236,7 +238,7 @@ export const LoginForm: React.FC<LoginForm.Props> = (props) => {
             <Button
               type="submit"
               variant="primary"
-              isDisabled={vm.shouldDisableFormControl}
+              isDisabled={vm.shouldDisableFormControl || !vm.isDataSharingChecked}
               form="login-form"
             >
               Log in

--- a/apps/agent/src/login-form/hooks/UseViewModel.ts
+++ b/apps/agent/src/login-form/hooks/UseViewModel.ts
@@ -34,6 +34,8 @@ export interface LoginFormViewModelInterface {
   shouldDisplayAlert: boolean;
   handleSubmit: React.FormEventHandler<HTMLFormElement>;
   handleReturnToAssistedMigration: () => void;
+  handleChangeDataSharingAllowed: (checked:boolean)=>void;
+  isDataSharingChecked: boolean;
 }
 
 const _computeFormControlVariant = (
@@ -58,6 +60,7 @@ export const useViewModel = (): LoginFormViewModelInterface => {
   );
   const formRef = useRef<HTMLFormElement>();
   const agentApi = useInjection<AgentApiInterface>(Symbols.AgentApi);
+  const [isDataSharingAllowed,setIsDataSharingAllowed] = useState<boolean>(DATA_SHARING_ALLOWED_DEFAULT_STATE);
 
   useMount(() => {
     const form = formRef.current;
@@ -65,7 +68,7 @@ export const useViewModel = (): LoginFormViewModelInterface => {
       return;
     }
 
-    form["isDataSharingAllowed"].checked = DATA_SHARING_ALLOWED_DEFAULT_STATE;
+    form["isDataSharingAllowed"].checked = isDataSharingAllowed;
   });
 
   useAsync(async () => {
@@ -226,5 +229,10 @@ export const useViewModel = (): LoginFormViewModelInterface => {
       const assistedMigrationUrl = import.meta.env.ASSISTED_MIGRATION_URL || 'http://localhost:3000/migrate/wizard';
       window.open(assistedMigrationUrl, '_blank', 'noopener,noreferrer');
     }, []),
+    handleChangeDataSharingAllowed: useCallback((checked)=>{
+      console.log(checked);
+      setIsDataSharingAllowed(checked);
+    },[]),
+    isDataSharingChecked: isDataSharingAllowed
   };
 };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-2399

If the checkbox is disabled (not agree) then the "login" button is disabled:
![Captura desde 2024-12-02 14-06-37](https://github.com/user-attachments/assets/f1c87305-4384-4f9d-9d3a-e75f3cac9f1f)

Only when user check the option to "Share the aggregate data" the "login" button is enabled:
![Captura desde 2024-12-02 14-06-40](https://github.com/user-attachments/assets/cb9f59dd-b86b-411b-b68a-40207fb6ad2c)
