### PR TITLE
ECOPROJECT_2533: Discovery VM link with instruction appears only on radio button trigger

### DIFF
--- a/apps/demo/src/migration-wizard/steps/connect/ConnectStep.tsx
+++ b/apps/demo/src/migration-wizard/steps/connect/ConnectStep.tsx
@@ -36,9 +36,7 @@ export const ConnectStep: React.FC = () => {
   
   useEffect(() => {
     if (!discoverySourcesContext.agentSelected && firstAgent) {
-      if (firstAgent.status === 'up-to-date') {        
-        discoverySourcesContext.selectAgent(firstAgent);
-      }
+      discoverySourcesContext.selectAgent(firstAgent);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [firstAgent]);


### PR DESCRIPTION
When 2 agents (or more) are exposed in the sources table, they are waiting for credentials to be supplied. 

However, the link for the login page does not appears right away - you need to press on the second radio button in order for the link to appear.


https://github.com/user-attachments/assets/7d0ba782-3a55-4f03-a8cd-5f5d38a6bec8

