### PR TITLE
ECOPROJECT-2585: Change buttons order in assessment wizard

### DIFF
--- a/apps/demo/src/migration-wizard/MigrationWizard.tsx
+++ b/apps/demo/src/migration-wizard/MigrationWizard.tsx
@@ -37,7 +37,15 @@ export const CustomWizardFooter: React.FC<CustomWizardFooterPropType> = ({
   const { goToNextStep, goToPrevStep, goToStepById } = useWizardContext();
   return (
     <>
-      <WizardFooterWrapper>
+      <WizardFooterWrapper>        
+        <Button
+          ouiaId="wizard-back-btn"
+          variant="secondary"
+          onClick={goToPrevStep}
+          isDisabled={isBackDisabled}
+        >
+          Back
+        </Button>
         <Button
           ouiaId="wizard-next-btn"
           variant="primary"
@@ -51,14 +59,6 @@ export const CustomWizardFooter: React.FC<CustomWizardFooterPropType> = ({
           isDisabled={isNextDisabled}
         >
           {nextButtonText ?? "Next"}
-        </Button>
-        <Button
-          ouiaId="wizard-back-btn"
-          variant="secondary"
-          onClick={goToPrevStep}
-          isDisabled={isBackDisabled}
-        >
-          Back
         </Button>
         {!isCancelHidden && (
           <Button


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-2585

The presented order of the next and back buttons should be: Back, Next 

![Captura desde 2025-01-21 11-33-59](https://github.com/user-attachments/assets/4ba24155-5d01-484d-a9d9-bb0ba97ca6bf)
