### PR TITLE
ECOPROJECT-2579: Changes behavior when we have source 'Waiting for credentials'

### DIFF
--- a/apps/demo/src/migration-wizard/steps/connect/ConnectStep.tsx
+++ b/apps/demo/src/migration-wizard/steps/connect/ConnectStep.tsx
@@ -13,6 +13,7 @@ import {
   Icon,
   Alert,
   Button,
+  AlertActionLink,
 } from "@patternfly/react-core";
 import { chart_color_blue_300 as blueColor } from "@patternfly/react-tokens/dist/esm/chart_color_blue_300";
 import { ClusterIcon, PlusCircleIcon } from "@patternfly/react-icons";
@@ -119,6 +120,33 @@ export const ConnectStep: React.FC = () => {
           <Alert isInline variant="danger" title="Download Source error">
             {discoverySourcesContext.errorDownloadingSource.message}
             </Alert>
+        )}
+      </StackItem>
+      <StackItem>
+      {discoverySourcesContext.agentSelected?.status ===
+          "waiting-for-credentials" && (
+          <Alert
+            isInline
+            variant="custom"
+            title="Discovery VM"
+            actionLinks={
+              <AlertActionLink
+                component="a"
+                href={discoverySourcesContext.agentSelected?.credentialUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {discoverySourcesContext.agentSelected?.credentialUrl}
+              </AlertActionLink>
+            }
+          >
+            <TextContent>
+              <Text>
+                Click the link below to connect the Discovery Source to your
+                VMware environment.
+              </Text>
+            </TextContent>
+          </Alert>
         )}
       </StackItem>
     </Stack>

--- a/apps/demo/src/migration-wizard/steps/connect/sources-table/AgentStatusView.tsx
+++ b/apps/demo/src/migration-wizard/steps/connect/sources-table/AgentStatusView.tsx
@@ -19,21 +19,43 @@ import {
 import globalDangerColor200 from "@patternfly/react-tokens/dist/esm/global_danger_color_200";
 import globalInfoColor100 from "@patternfly/react-tokens/dist/esm/global_info_color_100";
 import globalSuccessColor100 from "@patternfly/react-tokens/dist/esm/global_success_color_100";
+import { Link } from "react-router-dom";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace AgentStatusView {
   export type Props = {
     status: Agent["status"];
     statusInfo?: Agent["statusInfo"];
+    credentialUrl?: Agent["credentialUrl"];
   };
 }
 
+const StatusInfoWaitingForCredentials: React.FC<{
+  credentialUrl?: Agent["credentialUrl"];
+}> = ({ credentialUrl }) => {
+  return (
+    <>
+      <TextContent>
+        <Text>
+          Click the link below to connect the Discovery Source to your VMware
+          environment.
+        </Text>
+      </TextContent>
+      {credentialUrl && (
+        <Link to={credentialUrl} target="_blank">
+          {credentialUrl}
+        </Link>
+      )}
+    </>
+  );
+};
+
 export const AgentStatusView: React.FC<AgentStatusView.Props> = (props) => {
-  const { status, statusInfo } = props;
+  const { status, statusInfo, credentialUrl } = props;
 
   const statusView = useMemo(() => {
     // eslint-disable-next-line prefer-const
-    let fake: Agent['status'] | null = null;
+    let fake: Agent["status"] | null = null;
     // fake = "not-connected";
     // fake = "waiting-for-credentials";
     // fake = "gathering-initial-inventory";
@@ -92,15 +114,21 @@ export const AgentStatusView: React.FC<AgentStatusView.Props> = (props) => {
     <Split hasGutter style={{ gap: "0.66rem" }}>
       <SplitItem>{statusView && statusView.icon}</SplitItem>
       <SplitItem>
-        {statusInfo ? (
+        {statusInfo || statusView && statusView.text==='Waiting for credentials' ? (
           <Popover
             aria-label={statusView && statusView.text}
             headerContent={statusView && statusView.text}
             headerComponent="h1"
             bodyContent={
-              <TextContent>
-                <Text>{statusInfo}</Text>
-              </TextContent>
+              statusView && statusView.text !== "Waiting for credentials" ? (
+                <TextContent>
+                  <Text>{statusInfo}</Text>
+                </TextContent>
+              ) : (
+                <StatusInfoWaitingForCredentials
+                  credentialUrl={credentialUrl}
+                />
+              )
             }
           >
             <Button variant="link" isInline>

--- a/apps/demo/src/migration-wizard/steps/connect/sources-table/SourcesTable.tsx
+++ b/apps/demo/src/migration-wizard/steps/connect/sources-table/SourcesTable.tsx
@@ -157,7 +157,7 @@ export const SourcesTable: React.FC = () => {
                     />
                   </Td>
                   <Td dataLabel={Columns.Status}>
-                    <AgentStatusView status={agent.status} statusInfo={agent.statusInfo} />
+                    <AgentStatusView status={agent.status} statusInfo={agent.statusInfo} credentialUrl={agent.credentialUrl}/>
                   </Td>
                   <Td dataLabel={Columns.Hosts}>
                     {(source?.inventory?.infra.totalHosts ?? VALUE_NOT_AVAILABLE)}
@@ -184,6 +184,7 @@ export const SourcesTable: React.FC = () => {
                             discoverySourcesContext.listAgents(),
                             discoverySourcesContext.listSources(),
                           ]);
+                          discoverySourcesContext.selectAgent(firstAgent);
                         }}
                       />
                     )}


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/ECOPROJECT-2579

This should be the expected behavior:

- the message should appear below the table right above the next button
- when selecting an environment that we don't need credentials for this should not appear
- when deleting an environment, the message should disappear 
- I like the idea of adding the link to the tooltip as well. 

Video with the new behavior:

https://github.com/user-attachments/assets/5d86413a-a561-4fff-813b-18e39e325b60

