### PR TITLE
ECOPROJECT-2749: Problems refreshing sources table

### DIFF
--- a/apps/demo/src/migration-wizard/steps/connect/sources-table/SourcesTable.tsx
+++ b/apps/demo/src/migration-wizard/steps/connect/sources-table/SourcesTable.tsx
@@ -28,11 +28,12 @@ export const SourcesTable: React.FC = () => {
     if (!areSourcesEquals(prevSourcesRef.current, discoverySourcesContext.sources)) {
       prevSourcesRef.current = discoverySourcesContext.sources;
       return discoverySourcesContext.sources
-        ? discoverySourcesContext.sources.sort((a: Source, b: Source) => a.id.localeCompare(b.id))
+        ? [...discoverySourcesContext.sources].sort((a: Source, b: Source) => a.id.localeCompare(b.id))
         : [];
     }
     return prevSourcesRef.current;
-  }, [discoverySourcesContext]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [discoverySourcesContext.sources]);
 
   const [firstSource, ..._otherSources] = memoizedSources ?? [];  
   const hasSources = memoizedSources && memoizedSources.length>0;


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/ECOPROJECT-2749

After booting an agent with the ova image, we expect the source in the table to have the status "Waiting for credentials", which only shown when we refresh the page.

if we will continue with the login, we will expect the status to be Ready, but it is also shown only on refresh.