### PR TITLE
fix: name expression to use like op

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/vmFilters.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmFilters.ts
@@ -29,11 +29,7 @@ export function filtersToByExpression(filters: VMFilters): string | undefined {
 
   // Search filter - searches in VM name only
   if (filters.search) {
-    // Escape special regex characters including forward slashes
-    const searchTerm = filters.search
-      .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-      .replace(/\//g, "\\/");
-    conditions.push(`name ~ /${searchTerm}/`);
+    conditions.push(`name like '${escapeFilterValue(filters.search)}'`);
   }
 
   // Status filter (powerstate field in backend)


### PR DESCRIPTION
This commit changes the name filter expression to use "like" op.

Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM filter search behavior to use substring matching instead of regex-based patterns, resulting in more intuitive and consistent search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->