### PR TITLE
fix: ECOPROJECT-4421 - align the agent report with the SaSS report

### DIFF
--- a/apps/agent-ui/src/common/components/DataSharingCheckbox.tsx
+++ b/apps/agent-ui/src/common/components/DataSharingCheckbox.tsx
@@ -63,7 +63,7 @@ export const DataSharingCheckbox: React.FC<DataSharingCheckboxProps> = ({
           Aggregated data does not include names of virtual machines, hosts,
           clusters, data centers, datastores, disks and networks.{" "}
           <a
-            href="https://www.redhat.com/en/about/privacy-policy"
+            href="https://kubev2v.github.io/openshift-migration-advisor-docs/docs/aggregated-data-report/"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/apps/agent-ui/src/pages/Report/components/ClustersOverview.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ClustersOverview.tsx
@@ -433,14 +433,13 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
             data={chartData}
             height={300}
             width={420}
-            donutThickness={9}
+            donutThickness={18}
             titleFontSize={34}
             legend={legend}
             title={title}
             subTitle={subTitle}
             subTitleColor="#9a9da0"
             itemsPerRow={chartData.length}
-            legendLabelFormatter={({ x }) => x}
             tooltipLabelFormatter={({ datum, percent }) =>
               `${datum.countDisplay}\n${percent.toFixed(1)}%`
             }

--- a/apps/agent-ui/src/pages/Report/components/CpuAndMemoryOverview.tsx
+++ b/apps/agent-ui/src/pages/Report/components/CpuAndMemoryOverview.tsx
@@ -219,7 +219,7 @@ export const CpuAndMemoryOverview: React.FC<CpuAndMemoryOverviewProps> = ({
           data={activeSlices}
           height={300}
           width={420}
-          donutThickness={9}
+          donutThickness={18}
           titleFontSize={34}
           legend={legend}
           legendWidth={680}
@@ -235,6 +235,9 @@ export const CpuAndMemoryOverview: React.FC<CpuAndMemoryOverviewProps> = ({
           }
           subTitleColor="#9a9da0"
           itemsPerRow={Math.ceil(activeSlices.length / 2)}
+          legendLabelFormatter={({ x, countDisplay }) =>
+            `${x} (${countDisplay})`
+          }
           tooltipLabelFormatter={({ datum, percent }) =>
             `${datum.countDisplay}\n${percent.toFixed(1)}%`
           }

--- a/apps/agent-ui/src/pages/Report/components/HostsOverview.tsx
+++ b/apps/agent-ui/src/pages/Report/components/HostsOverview.tsx
@@ -113,7 +113,7 @@ export const HostsOverview: React.FC<HostsOverviewProps> = ({
           data={slices}
           height={300}
           width={420}
-          donutThickness={9}
+          donutThickness={18}
           titleFontSize={34}
           legend={legend}
           title={`${totalHosts}`}
@@ -121,7 +121,6 @@ export const HostsOverview: React.FC<HostsOverviewProps> = ({
           subTitleColor="#9a9da0"
           itemsPerRow={2}
           marginLeft="0%"
-          legendLabelFormatter={({ x }: { x: string }) => x}
           tooltipLabelFormatter={({
             datum,
             percent,

--- a/apps/agent-ui/src/pages/Report/components/MigrationChart.tsx
+++ b/apps/agent-ui/src/pages/Report/components/MigrationChart.tsx
@@ -7,6 +7,8 @@ import {
 } from "@patternfly/react-core";
 import { InfoCircleIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Tr } from "@patternfly/react-table";
+import { chart_color_blue_300 } from "@patternfly/react-tokens/dist/esm/chart_color_blue_300";
+import { chart_color_red_orange_400 } from "@patternfly/react-tokens/dist/esm/chart_color_red_orange_400";
 import type React from "react";
 import { useMemo } from "react";
 
@@ -24,7 +26,12 @@ interface MigrationChartProps {
   barHeight?: number;
 }
 
-const legendColors = ["#28a745", "#f0ad4e", "#d9534f", "#C9190B"];
+const legendColors = [
+  chart_color_blue_300.value,
+  chart_color_red_orange_400.value,
+  "#f0ad4e",
+  "#6a6e73",
+];
 
 const MigrationChart: React.FC<MigrationChartProps> = ({
   data,

--- a/apps/agent-ui/src/pages/Report/components/MigrationDonutChart.tsx
+++ b/apps/agent-ui/src/pages/Report/components/MigrationDonutChart.tsx
@@ -28,6 +28,7 @@ interface MigrationDonutChartProps {
   subTitleColor?: string;
   itemsPerRow?: number;
   marginLeft?: string;
+  labelFontSize?: number;
   titleFontSize?: number;
   subTitleFontSize?: number;
   donutThickness?: number;
@@ -57,11 +58,6 @@ const legendStyles = {
   icon: css`
   margin-right: 4px;
   `,
-  centeredWrapper: css`
-    display: flex;
-    justify-content: center;
-    width: 100%;
-  `,
 };
 
 const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
@@ -77,6 +73,7 @@ const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
   subTitleColor = "#000000",
   itemsPerRow = 1,
   marginLeft = "0%",
+  labelFontSize = 14,
   titleFontSize = 28,
   subTitleFontSize = 14,
   donutThickness = 45,
@@ -136,6 +133,27 @@ const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
       symbol: { fill: getColor(item.legendCategory) },
     }));
   }, [chartData, getColor, legendLabelFormatter]);
+
+  const legendWidthValue = legendWidth ?? 800;
+
+  const legendX = useMemo(() => {
+    const symbolAndGap = 34;
+    const charWidth = labelFontSize * 0.55;
+    const itemWidths = legendData.map(
+      (d) => symbolAndGap + d.name.length * charWidth,
+    );
+    const numCols = Math.min(legendData.length, itemsPerRow);
+    const gutter = 16;
+    let contentWidth = (numCols - 1) * gutter;
+    for (let c = 0; c < numCols; c++) {
+      let maxW = 0;
+      for (let i = c; i < itemWidths.length; i += itemsPerRow) {
+        maxW = Math.max(maxW, itemWidths[i] ?? 0);
+      }
+      contentWidth += maxW;
+    }
+    return Math.max(0, (legendWidthValue - contentWidth) / 2);
+  }, [legendData, itemsPerRow, legendWidthValue, labelFontSize]);
 
   const innerRadius = useMemo(() => {
     const outerApprox = Math.min(width, height) / 2;
@@ -373,15 +391,14 @@ const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
             ))}
           </Flex>
         ) : (
-          // Standard non-clickable legend (centered block)
-          <div className={legendStyles.centeredWrapper}>
-            <ChartLegend
-              data={legendData}
-              orientation="horizontal"
-              width={legendWidth ?? 800}
-              itemsPerRow={itemsPerRow}
-            />
-          </div>
+          // Standard non-clickable legend (centered via x offset)
+          <ChartLegend
+            data={legendData}
+            orientation="horizontal"
+            width={legendWidthValue}
+            itemsPerRow={itemsPerRow}
+            x={legendX}
+          />
         )}
       </Flex>
     </Flex>

--- a/apps/agent-ui/src/pages/Report/components/NetworkOverview.tsx
+++ b/apps/agent-ui/src/pages/Report/components/NetworkOverview.tsx
@@ -322,14 +322,13 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
             data={chartData}
             height={300}
             width={420}
-            donutThickness={9}
+            donutThickness={18}
             titleFontSize={34}
             legend={legend}
             title={title}
             subTitle={subTitle}
             subTitleColor="#9a9da0"
             itemsPerRow={Math.ceil(chartData.length / 2)}
-            legendLabelFormatter={({ x }) => x}
             tooltipLabelFormatter={({ datum, percent }) =>
               `${datum.countDisplay}\n${percent.toFixed(1)}%\nVLAN: ${legendVlanMap[datum.legendCategory] ?? "-"}`
             }
@@ -341,7 +340,7 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
             data={nicChartData}
             height={300}
             width={420}
-            donutThickness={9}
+            donutThickness={18}
             titleFontSize={34}
             legend={nicLegend}
             title={nicTitle}

--- a/apps/agent-ui/src/pages/Report/components/OSDistribution.tsx
+++ b/apps/agent-ui/src/pages/Report/components/OSDistribution.tsx
@@ -9,6 +9,7 @@ import {
 } from "@patternfly/react-core";
 import { DesktopIcon, InfoCircleIcon } from "@patternfly/react-icons";
 import type React from "react";
+import { chartColorFailure, chartColorSuccess } from "./constants";
 import { dashboardStyles } from "./dashboardStyles";
 import MigrationChart from "./MigrationChart";
 
@@ -32,7 +33,23 @@ export const OSDistribution: React.FC<OSDistributionProps> = ({
   );
 
   const dataEntries = Object.entries(osData).filter(([os]) => os.trim() !== "");
-  const sorted = dataEntries.sort(([, a], [, b]) => b.count - a.count);
+
+  const osSortGroup = (osInfo: {
+    count: number;
+    supported: boolean;
+    upgradeRecommendation: string;
+  }): number => {
+    if (osInfo.supported) return 1;
+    if ((osInfo.upgradeRecommendation?.trim() ?? "") !== "") return 2;
+    return 3;
+  };
+
+  const sorted = [...dataEntries].sort(([, a], [, b]) => {
+    const groupA = osSortGroup(a);
+    const groupB = osSortGroup(b);
+    if (groupA !== groupB) return groupA - groupB;
+    return b.count - a.count;
+  });
 
   const chartData = sorted.map(([os, osInfo]) => ({
     name: os,
@@ -44,8 +61,8 @@ export const OSDistribution: React.FC<OSDistributionProps> = ({
   }));
 
   const customLegend = {
-    "Supported by MTV": "#28a745",
-    "Not supported by MTV": "#f0ad4e",
+    "Supported by MTV": chartColorSuccess,
+    "Not supported by MTV": chartColorFailure,
   };
 
   return (

--- a/apps/agent-ui/src/pages/Report/components/StorageOverview.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOverview.tsx
@@ -334,7 +334,7 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
     () => ({
       height: 300,
       width: 420,
-      donutThickness: 9,
+      donutThickness: 18,
       titleFontSize: 34,
       subTitleColor: "#9a9da0",
     }),
@@ -506,6 +506,9 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
                   : `${totals.totalSize.toFixed(2)} TB`
               }
               itemsPerRow={Math.ceil(chartData.length / 2)}
+              legendLabelFormatter={({ x, countDisplay }) =>
+                `${x} (${countDisplay})`
+              }
               tooltipLabelFormatter={({ datum, percent }) =>
                 `${datum.x}: ${datum.countDisplay}\n${percent.toFixed(1)}%`
               }

--- a/apps/agent-ui/src/pages/Report/components/VMMigrationStatus.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMMigrationStatus.tsx
@@ -19,6 +19,7 @@ import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Symbols } from "../../../main/Symbols";
+import { chartColorFailure, chartColorSuccess } from "./constants";
 import { dashboardStyles } from "./dashboardStyles";
 import MigrationDonutChart from "./MigrationDonutChart";
 import { createVMFilterURL } from "./vmNavigation";
@@ -205,16 +206,16 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
       legendCategory: "Migratable",
     },
     {
-      name: "Non-Migratable",
+      name: "Unready for migration",
       count: data.nonMigratable,
       countDisplay: `${data.nonMigratable} VMs`,
-      legendCategory: "Non-Migratable",
+      legendCategory: "Unready for migration",
     },
   ];
 
   const legend = {
-    Migratable: "#28a745",
-    "Non-Migratable": "#dc3545",
+    Migratable: chartColorSuccess,
+    "Unready for migration": chartColorFailure,
   };
 
   const breakdownData = useMemo(() => {
@@ -265,7 +266,7 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
           justifyContent={{ default: "justifyContentSpaceBetween" }}
         >
           <FlexItem>
-            <VirtualMachineIcon /> VM migration status
+            <VirtualMachineIcon /> VM Migration status
           </FlexItem>
           {!isExportMode && (
             <FlexItem>
@@ -315,13 +316,16 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
             legend={legend}
             height={300}
             width={420}
-            donutThickness={9}
+            donutThickness={18}
             padAngle={1}
             title={`${totalVMs}`}
             subTitle="VMs"
             subTitleColor="#9a9da0"
             titleFontSize={34}
             itemsPerRow={2}
+            legendLabelFormatter={({ x, countDisplay }) =>
+              `${x} (${countDisplay})`
+            }
             onItemClick={handleItemClick}
             onTitleClick={!isExportMode ? handleTitleClick : undefined}
           />

--- a/apps/agent-ui/src/pages/Report/components/constants.ts
+++ b/apps/agent-ui/src/pages/Report/components/constants.ts
@@ -1,0 +1,10 @@
+import { chart_color_blue_300 } from "@patternfly/react-tokens/dist/esm/chart_color_blue_300";
+import { chart_color_red_orange_400 } from "@patternfly/react-tokens/dist/esm/chart_color_red_orange_400";
+
+/**
+ * PatternFly chart color semantics (https://www.patternfly.org/charts/colors-for-charts/design-guidelines/#best-practices):
+ *   Blue  → success / migratable / supported
+ *   Red-orange → failure / non-migratable / unsupported
+ */
+export const chartColorSuccess = chart_color_blue_300.value;
+export const chartColorFailure = chart_color_red_orange_400.value;


### PR DESCRIPTION
The agent report page (apps/agent-ui) has not been updated to reflect the recent UI changes deployed on the SaaS report. 
This PR addressed these changes:

https://github.com/user-attachments/assets/f74e8c97-64d8-47dd-ae10-32766cd31f63





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced donut charts with improved legend formatting and dynamic label sizing support.

* **UI/Visual Improvements**
  * Increased donut chart thickness for better visual clarity.
  * Improved legend centering and alignment across charts.
  * Updated chart color scheme for consistent visual design.
  * Reorganized OS distribution display to prioritize supported systems.
  * Renamed "Non-Migratable" status to "Unready for migration."

* **Documentation**
  * Updated data sharing information link to kubev2v.github.io documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->