### PR TITLE
fix: ECOPROJECT-4499 - 'Reset deep inspection' configuration fails when no VMs are selected

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/DeepInspectionModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/DeepInspectionModal.tsx
@@ -271,12 +271,22 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
   const MAX_VMS = 10;
   const tooManyVMs = selectedVMIds.length > MAX_VMS;
 
+  const hasVMsSelected = selectedVMIds.length > 0;
+
   const canConfigure =
     vddkStatus === "configured" &&
     credentialsStatus === "configured" &&
-    !tooManyVMs;
+    (!hasVMsSelected || !tooManyVMs);
 
   const handleConfigure = async () => {
+    // When no VMs are selected the user is only updating the configuration
+    // (VDDK / credentials). Both are already persisted by their own actions,
+    // so there is nothing left to do — just close the modal.
+    if (!hasVMsSelected) {
+      handleClose();
+      return;
+    }
+
     setConfiguring(true);
     setGlobalError(null);
 
@@ -321,7 +331,11 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
       <ModalHeader
         title="Set up deep inspection"
         labelId="deep-inspection-modal-title"
-        description={`Configure deep inspection for ${selectedVMIds.length} selected VM${selectedVMIds.length !== 1 ? "s" : ""}`}
+        description={
+          hasVMsSelected
+            ? `Configure deep inspection for ${selectedVMIds.length} selected VM${selectedVMIds.length !== 1 ? "s" : ""}`
+            : "Update the VDDK archive and credentials for deep inspection"
+        }
       />
       <ModalBody id="deep-inspection-modal-body">
         <Content component="p" style={{ marginBottom: "24px" }}>
@@ -566,7 +580,7 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
           isLoading={configuring}
           isDisabled={!canConfigure || configuring}
         >
-          Configure
+          {hasVMsSelected ? "Configure" : "Save configuration"}
         </Button>
         <Button variant="link" onClick={handleClose} isDisabled={configuring}>
           Cancel


### PR DESCRIPTION
- With 0 VMs selected: header says "Update the VDDK archive and credentials for deep inspection", button says "Save configuration".
<img width="826" height="389" alt="Captura desde 2026-04-29 11-47-13" src="https://github.com/user-attachments/assets/428df23b-9cb1-4d4d-a45a-58583fa720b4" />

- With VMs selected: header says "Configure deep inspection for N selected VM(s)", button says "Configure" — identical to the previous behavior.
<img width="826" height="389" alt="Captura desde 2026-04-29 11-47-04" src="https://github.com/user-attachments/assets/613b1a58-544b-416b-bc8b-ce7a5d851a09" />

[recording - 2026-04-29T114414.139.webm](https://github.com/user-attachments/assets/c9937480-d284-469b-831c-e91e6c66a130)
