### PR TITLE
fix: ECOPROJECT-4523 - 'Run deep inspection' remains disabled during an active run blocking selection of additional VMs

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -1295,7 +1295,7 @@ export const VMTable: React.FC<VMTableProps> = ({
                 <Button
                   variant="primary"
                   icon={<MagicIcon />}
-                  isDisabled={selectedVMs.size === 0 || inspectionActive}
+                  isDisabled={selectedVMs.size === 0}
                   onClick={() => onRunDeepInspection?.()}
                 >
                   Run deep inspection
@@ -1479,7 +1479,10 @@ export const VMTable: React.FC<VMTableProps> = ({
                     rowIndex,
                     onSelect: (_event, isSelected) =>
                       onSelectVM(vm, isSelected),
-                    isSelected: selectedVMs.has(vm.id),
+                    isSelected:
+                      selectedVMs.has(vm.id) ||
+                      vm.inspectionStatus?.state === "running" ||
+                      vm.inspectionStatus?.state === "pending",
                     isDisabled:
                       vm.inspectionStatus?.state === "running" ||
                       vm.inspectionStatus?.state === "pending",
@@ -1592,7 +1595,6 @@ export const VMTable: React.FC<VMTableProps> = ({
                         return (
                           <DropdownItem
                             key="inspect"
-                            isDisabled={inspectionActive}
                             onClick={() => onRunDeepInspection?.(vm.id)}
                           >
                             Run deep inspection

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -69,6 +69,17 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     if (includeVmId) {
       merged.add(includeVmId);
     }
+    // startInspection replaces the entire run on the server, so VMs that are
+    // currently running or pending must be included in every new call or the
+    // server will cancel them by omission.
+    for (const vm of vms) {
+      if (
+        vm.inspectionStatus?.state === "running" ||
+        vm.inspectionStatus?.state === "pending"
+      ) {
+        merged.add(vm.id);
+      }
+    }
     if (merged.size > 0) {
       setSelectedVMs(merged);
       setIsInspectionModalOpen(true);


### PR DESCRIPTION

- WMs now show checked/disabled when deep inspection is running
- Starting a new inspection no longer cancels VMs already being inspected

[recording - 2026-04-29T121612.828.webm](https://github.com/user-attachments/assets/8837c588-15ef-4437-bbd2-172e1a2f5b8d)
