### PR TITLE
fix: ECOPROJECT-4498 - Deep inspection status hangs on Running in UI after backend completes

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -49,6 +49,16 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   const [inspectionActive, setInspectionActive] = useState(false);
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const onRefreshVMsRef = useRef(onRefreshVMs);
+  // Tracks whether the current run has been observed in running/pending state
+  // at least once. Guards against stopping the poll too early when VMs still
+  // carry a terminal inspectionStatus from a previous run at the moment the
+  // first refresh returns (before the server updates them to "pending").
+  const seenRunningRef = useRef(false);
+  // Fallback: stop polling after this many attempts even if the server never
+  // transitions any VM to running/pending (e.g. the run completes before the
+  // first refresh or a transient error prevents observation).
+  const MAX_POLL_ATTEMPTS = 60; // 60 × 5 s = 5 min ceiling
+  const pollAttemptsRef = useRef(0);
 
   useEffect(() => {
     onRefreshVMsRef.current = onRefreshVMs;
@@ -108,6 +118,8 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   }, [agentApi, onRefreshVMs, stopPolling]);
 
   const handleInspectionStarted = useCallback(() => {
+    seenRunningRef.current = false;
+    pollAttemptsRef.current = 0;
     setInspectionActive(true);
     setSelectedVMs(new Set());
     onRefreshVMsRef.current?.();
@@ -121,13 +133,28 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   useEffect(() => {
     if (!inspectionActive) return;
 
-    const allDone = vms.every((vm) => {
-      if (!vm.inspectionStatus) return true;
-      const s = vm.inspectionStatus.state;
-      return s === "completed" || s === "error" || s === "canceled";
-    });
+    const hasRunningOrPending = vms.some(
+      (vm) =>
+        vm.inspectionStatus?.state === "running" ||
+        vm.inspectionStatus?.state === "pending",
+    );
 
-    if (allDone && vms.some((vm) => vm.inspectionStatus != null)) {
+    if (hasRunningOrPending) {
+      seenRunningRef.current = true;
+    }
+
+    pollAttemptsRef.current += 1;
+
+    // Only stop polling after the current run has been observed in an active
+    // state at least once. Without this guard, stale terminal statuses from a
+    // previous run would satisfy "allDone" on the very first refresh (before
+    // the server transitions the VMs to "pending"), killing the poll early.
+    // Fallback: if the server never transitions any VM to running/pending
+    // within MAX_POLL_ATTEMPTS refreshes, stop polling to avoid an infinite
+    // loop (e.g. run completes before first observation, transient API error).
+    const exhausted = pollAttemptsRef.current >= MAX_POLL_ATTEMPTS;
+    if ((seenRunningRef.current && !hasRunningOrPending) || exhausted) {
+      seenRunningRef.current = true;
       stopPolling();
       setInspectionActive(false);
     }


### PR DESCRIPTION
The fix introduces a seenRunningRef flag that is reset every time a new inspection starts. The poll is now only stopped after two conditions are both true: the current run has been observed in an active ("running" or "pending") state at least once, and all VMs have since left that state.

[recording - 2026-04-29T123004.552.webm](https://github.com/user-attachments/assets/71e9bb78-61a9-4d6b-956f-f2c3963e3d6d)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced virtual machine inspection polling to prevent premature termination by ensuring the system observes an active running or pending state before stopping polls, eliminating issues with stale status values from previous runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->