### PR TITLE
feat: ECOPROJECT-4550 - Add Used Resources column

### DIFF
--- a/apps/agent-ui/package.json
+++ b/apps/agent-ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.0",
     "@migration-planner-ui/ioc": "workspace:*",
-    "@openshift-migration-advisor/agent-sdk": "0.8.0-89b5466bbbac",
+    "@openshift-migration-advisor/agent-sdk": "0.12.0-1f1dc16fb9e5",
     "@patternfly/react-charts": "^8.0.0",
     "@patternfly/react-core": "^6.4.0",
     "@patternfly/react-icons": "^6.4.0",

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -128,6 +128,7 @@ type ColumnKey =
   | "name"
   | "vCenterState"
   | "id"
+  | "usedResources"
   | "datacenter"
   | "cluster"
   | "diskSize"
@@ -136,13 +137,27 @@ type ColumnKey =
   | "migratable"
   | "deepInspection";
 
-type SortableColumn = ColumnKey;
+// Backend supports sorting for these columns only
+const SORTABLE_COLUMNS = [
+  "name",
+  "vCenterState",
+  "cluster",
+  "diskSize",
+  "memory",
+  "issues",
+] as const;
+
+type SortableColumn = (typeof SORTABLE_COLUMNS)[number];
+
+const isSortableColumn = (key: ColumnKey): key is SortableColumn =>
+  SORTABLE_COLUMNS.includes(key as SortableColumn);
 
 const Columns: Record<ColumnKey, string> = {
   name: "Name",
   vCenterState: "Status",
   migratable: "Migration Readiness",
   id: "ID",
+  usedResources: "Used resources",
   datacenter: "Data center",
   cluster: "Cluster",
   diskSize: "Disk size",
@@ -158,7 +173,7 @@ const MANDATORY_COLUMNS: ColumnKey[] = ["name"];
 const DEFAULT_VISIBLE_COLUMNS: ColumnKey[] = [...ALL_COLUMN_KEYS];
 
 const VISIBLE_COLUMNS_KEY = "vmTable.visibleColumns";
-const VISIBLE_COLUMNS_VERSION = 2;
+const VISIBLE_COLUMNS_VERSION = 3;
 
 const statusLabels: Record<string, string> = {
   poweredOn: "Powered on",
@@ -225,11 +240,6 @@ interface AppliedFilter {
 // Emotion styles to fix sortable column header layout shifts
 const styles = {
   vmTable: css`
-    table {
-      table-layout: fixed;
-      width: 100%;
-    }
-
     th button {
       display: flex;
       align-items: center;
@@ -432,7 +442,7 @@ export const VMTable: React.FC<VMTableProps> = ({
       }).map((key) => ({
         key,
         label: Columns[key],
-        sortable: true,
+        sortable: isSortableColumn(key),
       })),
     [isColumnVisible, hasInspectionResults],
   );
@@ -699,8 +709,7 @@ export const VMTable: React.FC<VMTableProps> = ({
   // No client-side filtering - handled by backend
   // VMs are already filtered, sorted, and paginated by the backend
 
-  // Backend supports sorting for these columns only
-  const backendFieldMap: Partial<Record<SortableColumn, string>> = {
+  const backendFieldMap: Record<SortableColumn, string> = {
     name: "name",
     vCenterState: "vCenterState",
     cluster: "cluster",
@@ -721,7 +730,7 @@ export const VMTable: React.FC<VMTableProps> = ({
 
   // Sort handler - triggers backend sort, tracks by column key
   const getSortParams = (
-    columnKey: SortableColumn,
+    columnKey: ColumnKey,
     columnIndex: number,
   ): ThProps["sort"] => ({
     sortBy: {
@@ -734,14 +743,13 @@ export const VMTable: React.FC<VMTableProps> = ({
       setSortByColumnKey(columnKey);
       setActiveSortDirection(direction);
 
-      if (columnKey === "deepInspection") {
-        // Client-side only — clear any active backend sort
-        onSortChange?.([]);
-      } else {
+      if (isSortableColumn(columnKey)) {
+        // Backend sort
         const sortField = backendFieldMap[columnKey];
-        if (sortField) {
-          onSortChange?.([`${sortField}:${direction}`]);
-        }
+        onSortChange?.([`${sortField}:${direction}`]);
+      } else {
+        // Client-side only (e.g., deepInspection) — clear any active backend sort
+        onSortChange?.([]);
       }
     },
     columnIndex,
@@ -1462,6 +1470,8 @@ export const VMTable: React.FC<VMTableProps> = ({
                     return 10;
                   case "issues":
                     return 10;
+                  case "usedResources":
+                    return 20;
                   case "deepInspection":
                     return 15;
                   default:
@@ -1552,6 +1562,13 @@ export const VMTable: React.FC<VMTableProps> = ({
                   </Td>
                 )}
                 {isColumnVisible("id") && <Td dataLabel="ID">{vm.id}</Td>}
+                {isColumnVisible("usedResources") && (
+                  <Td dataLabel="Used resources" modifier="fitContent">
+                    CPU: <b>{vm.utilizationCpuP95 || 0}%</b> | Disk:{" "}
+                    <b>{vm.utilizationDisk || 0}%</b> | RAM:{" "}
+                    <b>{vm.utilizationMemP95 || 0}%</b>
+                  </Td>
+                )}
                 {isColumnVisible("datacenter") && (
                   <Td dataLabel="Data center">{vm.datacenter || "—"}</Td>
                 )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,7 +391,7 @@ __metadata:
   dependencies:
     "@emotion/css": "npm:^11.13.0"
     "@migration-planner-ui/ioc": "workspace:*"
-    "@openshift-migration-advisor/agent-sdk": "npm:0.8.0-89b5466bbbac"
+    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-1f1dc16fb9e5"
     "@patternfly/react-charts": "npm:^8.0.0"
     "@patternfly/react-core": "npm:^6.4.0"
     "@patternfly/react-icons": "npm:^6.4.0"
@@ -456,10 +456,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openshift-migration-advisor/agent-sdk@npm:0.8.0-89b5466bbbac":
-  version: 0.8.0-89b5466bbbac
-  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.8.0-89b5466bbbac"
-  checksum: 10c0/24d4d475bc2b5df57239ac18a42acf1119dcdb4c99246c6cb4274f754b44ea9e37fa5d1721233002a836c1f6cda7762d833aa97d702c630620cf3f0c4818875b
+"@openshift-migration-advisor/agent-sdk@npm:0.12.0-1f1dc16fb9e5":
+  version: 0.12.0-1f1dc16fb9e5
+  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-1f1dc16fb9e5"
+  checksum: 10c0/12d748102c5bdd16aabb713cd73806b06aafccab006a7851c7244eaf8ea0acf2e74de9688343d7766d3ac9d0607019d64aff54bdb23c7b2ecba051488b19b924
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The agent API returns some metrics per VM.
We should display a new Used resources column with CPU Disk and RAM information: CPU: 0% | Disk: 0% | RAM: 0%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the core agent SDK dependency to a newer version for improved compatibility and stability.

* **New Features**
  * Added a "Used Resources" column to VM reports showing per-VM CPU, memory, and disk utilization percentages.

* **Style/UI**
  * Refined table header sizing and column display; column visibility persists across sessions.
  * Sorting indicators now appear only on explicitly defined sortable columns for clearer UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->