### PR TITLE
feat: ECOPROJECT-4560-Add TP badge to the 'Storage Offload estimator'

### DIFF
--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -36,6 +36,7 @@ import { Symbols } from "../../main/Symbols";
 import { buildClusterViewModel, type ClusterOption } from "./clusterView";
 import { Dashboard, VirtualMachinesView } from "./components/index";
 import { StorageOffloadTab } from "./components/StorageOffloadEstimatorModal";
+import { TechnologyPreviewBadge } from "./components/TechnologyPreviewBadge";
 import {
   filtersToByExpression,
   hasActiveFilters,
@@ -732,7 +733,11 @@ export const ReportContainer: React.FC = () => {
             </Tab>
             <Tab
               eventKey={2}
-              title={<TabTitleText>Storage offload estimator</TabTitleText>}
+              title={
+                <TabTitleText>
+                  Storage offload estimator <TechnologyPreviewBadge text="TP" />
+                </TabTitleText>
+              }
             >
               <StorageOffloadTab basePath={forecasterBasePath} />
             </Tab>


### PR DESCRIPTION
<img width="1562" height="817" alt="Captura desde 2026-05-04 09-40-27" src="https://github.com/user-attachments/assets/163b1949-4b25-4cee-9e40-ef4fc0be0fbb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a technology preview badge to the "Storage offload estimator" tab to indicate preview status.
  * The badge appears alongside the tab label for clearer visibility, helping users identify experimental/preview functionality at a glance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->