### PR TITLE
fix: solving issues deep inspector

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/DeepInspectionModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/DeepInspectionModal.tsx
@@ -291,9 +291,23 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
     setGlobalError(null);
 
     try {
-      await agentApi.startInspection({
-        startInspectionRequest: { vmIds: selectedVMIds },
-      });
+      try {
+        await agentApi.startInspection({
+          startInspectionRequest: { vmIds: selectedVMIds },
+        });
+      } catch (startErr) {
+        // The server keeps the inspector process alive even after all VMs
+        // reach a terminal state, so startInspection rejects with
+        // "already in progress" on re-runs or when adding VMs mid-run.
+        // Stop the stale inspector, wait for teardown, then restart with
+        // the full VM list.
+        if (!(startErr instanceof ResponseError)) throw startErr;
+        await agentApi.stopInspection();
+        await new Promise((r) => setTimeout(r, 1000));
+        await agentApi.startInspection({
+          startInspectionRequest: { vmIds: selectedVMIds },
+        });
+      }
       onInspectionStarted();
       handleClose();
     } catch (err) {

--- a/apps/agent-ui/src/pages/Report/components/DeepInspectionModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/DeepInspectionModal.tsx
@@ -278,6 +278,27 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
     credentialsStatus === "configured" &&
     (!hasVMsSelected || !tooManyVMs);
 
+  const isInspectorRunning = async (): Promise<boolean> => {
+    try {
+      const status = await agentApi.getInspectorStatus({});
+      return status.state === "running" || status.state === "Initiating";
+    } catch {
+      // Can't determine state — assume it may be running so the caller
+      // attempts a stop, which is harmless if it's already stopped.
+      return true;
+    }
+  };
+
+  const waitForInspectorReady = async (): Promise<void> => {
+    const MAX_WAIT_ATTEMPTS = 10;
+    const POLL_INTERVAL_MS = 500;
+    for (let i = 0; i < MAX_WAIT_ATTEMPTS; i++) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      if (!(await isInspectorRunning())) return;
+    }
+    // Best-effort: proceed even if the inspector didn't fully stop.
+  };
+
   const handleConfigure = async () => {
     // When no VMs are selected the user is only updating the configuration
     // (VDDK / credentials). Both are already persisted by their own actions,
@@ -291,23 +312,18 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
     setGlobalError(null);
 
     try {
-      try {
-        await agentApi.startInspection({
-          startInspectionRequest: { vmIds: selectedVMIds },
-        });
-      } catch (startErr) {
-        // The server keeps the inspector process alive even after all VMs
-        // reach a terminal state, so startInspection rejects with
-        // "already in progress" on re-runs or when adding VMs mid-run.
-        // Stop the stale inspector, wait for teardown, then restart with
-        // the full VM list.
-        if (!(startErr instanceof ResponseError)) throw startErr;
+      // If the inspector is still alive (from a previous run or an active
+      // one), stop it and wait for the server to finish tearing it down
+      // before starting a new run with the full VM list.
+      const inspectorRunning = await isInspectorRunning();
+      if (inspectorRunning) {
         await agentApi.stopInspection();
-        await new Promise((r) => setTimeout(r, 1000));
-        await agentApi.startInspection({
-          startInspectionRequest: { vmIds: selectedVMIds },
-        });
+        await waitForInspectorReady();
       }
+
+      await agentApi.startInspection({
+        startInspectionRequest: { vmIds: selectedVMIds },
+      });
       onInspectionStarted();
       handleClose();
     } catch (err) {

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -54,11 +54,16 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   // carry a terminal inspectionStatus from a previous run at the moment the
   // first refresh returns (before the server updates them to "pending").
   const seenRunningRef = useRef(false);
-  // Fallback: stop polling after this many attempts even if the server never
-  // transitions any VM to running/pending (e.g. the run completes before the
-  // first refresh or a transient error prevents observation).
-  const MAX_POLL_ATTEMPTS = 60; // 60 × 5 s = 5 min ceiling
-  const pollAttemptsRef = useRef(0);
+  // Number of poll responses received since the current run started.
+  // Incremented inside the setInterval callback (not in the render-triggered
+  // effect) so it counts actual server round-trips, not React re-renders.
+  const pollTicksRef = useRef(0);
+  // Minimum poll ticks before we allow the "allDone" check to stop polling.
+  // Gives the server time to transition VMs to "pending" even when the very
+  // first response still carries stale terminal states from a previous run.
+  const MIN_POLL_TICKS_BEFORE_DONE = 2;
+  // Fallback ceiling to avoid polling forever.
+  const MAX_POLL_TICKS = 60; // 60 × 5 s = 5 min
 
   useEffect(() => {
     onRefreshVMsRef.current = onRefreshVMs;
@@ -136,13 +141,14 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
 
   const handleInspectionStarted = useCallback(() => {
     seenRunningRef.current = false;
-    pollAttemptsRef.current = 0;
+    pollTicksRef.current = 0;
     setInspectionActive(true);
     setSelectedVMs(new Set());
     onRefreshVMsRef.current?.();
 
     stopPolling();
     pollingRef.current = setInterval(() => {
+      pollTicksRef.current += 1;
       onRefreshVMsRef.current?.();
     }, 5000);
   }, [stopPolling]);
@@ -160,18 +166,22 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
       seenRunningRef.current = true;
     }
 
-    pollAttemptsRef.current += 1;
+    const ticks = pollTicksRef.current;
 
-    // Only stop polling after the current run has been observed in an active
-    // state at least once. Without this guard, stale terminal statuses from a
-    // previous run would satisfy "allDone" on the very first refresh (before
-    // the server transitions the VMs to "pending"), killing the poll early.
-    // Fallback: if the server never transitions any VM to running/pending
-    // within MAX_POLL_ATTEMPTS refreshes, stop polling to avoid an infinite
-    // loop (e.g. run completes before first observation, transient API error).
-    const exhausted = pollAttemptsRef.current >= MAX_POLL_ATTEMPTS;
-    if ((seenRunningRef.current && !hasRunningOrPending) || exhausted) {
-      seenRunningRef.current = true;
+    // Two ways to know the run finished:
+    // 1. We observed running/pending at some point and now all VMs left that
+    //    state (the original fast-path).
+    // 2. We've waited at least MIN_POLL_TICKS_BEFORE_DONE server round-trips
+    //    and no VM is running/pending. This covers the re-run case where the
+    //    inspection completes so fast that we never catch the transient
+    //    running/pending state — after a few ticks the server has had enough
+    //    time to transition VMs, so terminal states are trustworthy.
+    const seenAndDone = seenRunningRef.current && !hasRunningOrPending;
+    const waitedAndDone =
+      ticks >= MIN_POLL_TICKS_BEFORE_DONE && !hasRunningOrPending;
+    const exhausted = ticks >= MAX_POLL_TICKS;
+
+    if (seenAndDone || waitedAndDone || exhausted) {
       stopPolling();
       setInspectionActive(false);
     }

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -176,10 +176,13 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     //    inspection completes so fast that we never catch the transient
     //    running/pending state — after a few ticks the server has had enough
     //    time to transition VMs, so terminal states are trustworthy.
+    // The MAX_POLL_TICKS ceiling only applies when no VM is still active —
+    // if VMs are genuinely running we must keep polling regardless of how
+    // long it takes.
     const seenAndDone = seenRunningRef.current && !hasRunningOrPending;
     const waitedAndDone =
       ticks >= MIN_POLL_TICKS_BEFORE_DONE && !hasRunningOrPending;
-    const exhausted = ticks >= MAX_POLL_TICKS;
+    const exhausted = ticks >= MAX_POLL_TICKS && !hasRunningOrPending;
 
     if (seenAndDone || waitedAndDone || exhausted) {
       stopPolling();


### PR DESCRIPTION
- fix: deep inspection status stuck on 'Running' after re-run
- fix: 'inspection already in progress' error when adding VMs to a running inspection

[recording - 2026-05-04T112137.300.webm](https://github.com/user-attachments/assets/31ce9f73-cc16-41aa-be7e-13cf3ee5890b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Deep inspection startup now detects when an inspector is already running, stops and waits for it to become ready, then reliably initiates the requested inspection to avoid start conflicts.
* Improved deep inspection polling so completion is detected more accurately (handles fast re-runs and sets sensible min/max polling bounds) to prevent premature termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->