### PR TITLE
feat: ECOPROJECT-4585 - Simplify Deep Inspection credentials flow

### DIFF
--- a/apps/agent-ui/package.json
+++ b/apps/agent-ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.0",
     "@migration-planner-ui/ioc": "workspace:*",
-    "@openshift-migration-advisor/agent-sdk": "0.12.0-e6e9d25bdc36",
+    "@openshift-migration-advisor/agent-sdk": "0.12.0-d5edcd6935f2",
     "@patternfly/react-charts": "^8.0.0",
     "@patternfly/react-core": "^6.4.0",
     "@patternfly/react-icons": "^6.4.0",

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -215,34 +215,33 @@ export const ReportContainer: React.FC = () => {
       return;
     }
 
-    const abortController = new AbortController();
+    let cancelled = false;
 
     const fetchUtilizationMetrics = async () => {
       try {
-        const response = await agentApi.getLatestRightsizingClusters({
-          signal: abortController.signal,
-        });
+        const response = await agentApi.getLatestRightsizingClusters({});
 
-        // Find cluster metrics for the selected cluster
-        const clusterMetrics = response.clusters?.find(
-          (cluster) => cluster.clusterId === selectedClusterId,
-        );
+        // Only update state if the effect hasn't been cleaned up
+        if (!cancelled) {
+          // Find cluster metrics for the selected cluster
+          const clusterMetrics = response.clusters?.find(
+            (cluster) => cluster.clusterId === selectedClusterId,
+          );
 
-        setUtilizationMetrics(clusterMetrics || null);
-      } catch (err) {
-        // Ignore abort errors
-        if (err instanceof Error && err.name === "AbortError") {
-          return;
+          setUtilizationMetrics(clusterMetrics || null);
         }
-        console.warn("Failed to fetch utilization metrics:", err);
-        setUtilizationMetrics(null);
+      } catch (err) {
+        if (!cancelled) {
+          console.warn("Failed to fetch utilization metrics:", err);
+          setUtilizationMetrics(null);
+        }
       }
     };
 
     fetchUtilizationMetrics();
 
     return () => {
-      abortController.abort();
+      cancelled = true;
     };
   }, [agentApi, selectedClusterId]);
 

--- a/apps/agent-ui/src/pages/Report/components/DeepInspectionModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/DeepInspectionModal.tsx
@@ -105,7 +105,6 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
 }) => {
   // Section expand/collapse
   const [vddkExpanded, setVddkExpanded] = useState(true);
-  const [credentialsExpanded, setCredentialsExpanded] = useState(true);
 
   // VDDK state
   const [vddkFile, setVddkFile] = useState<File | null>(null);
@@ -119,10 +118,6 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
   const [vcenterUrl, setVcenterUrl] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [credentialsStatus, setCredentialsStatus] =
-    useState<SectionStatus>("notConfigured");
-  const [credentialsSaving, setCredentialsSaving] = useState(false);
-  const [credentialsError, setCredentialsError] = useState<string | null>(null);
 
   // Global state
   const [configuring, setConfiguring] = useState(false);
@@ -147,20 +142,12 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
     try {
       const status: InspectorStatus = await agentApi.getInspectorStatus({
         includeVddk: true,
-        includeCredentials: true,
       });
 
       if (status.vddk) {
         setVddkStatus("configured");
         setVddkProps(status.vddk);
         setVddkExpanded(false);
-      }
-
-      if (status.credentials) {
-        setCredentialsStatus("configured");
-        setVcenterUrl(status.credentials.url || "");
-        setUsername(status.credentials.username || "");
-        setCredentialsExpanded(false);
       }
     } catch (err) {
       const isExpectedNotConfigured =
@@ -188,13 +175,9 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
     setVcenterUrl("");
     setUsername("");
     setPassword("");
-    setCredentialsStatus("notConfigured");
-    setCredentialsSaving(false);
-    setCredentialsError(null);
     setConfiguring(false);
     setGlobalError(null);
     setVddkExpanded(true);
-    setCredentialsExpanded(true);
   };
 
   const handleClose = () => {
@@ -240,48 +223,25 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
     }
   };
 
-  const handleCredentialsSave = async () => {
-    if (!vcenterUrl || !username || !password) return;
-
-    setCredentialsSaving(true);
-    setCredentialsError(null);
-
-    try {
-      await agentApi.putInspectorCredentials({
-        vcenterCredentials: {
-          url: vcenterUrl,
-          username,
-          password,
-        },
-      });
-      setCredentialsStatus("configured");
-      setCredentialsExpanded(false);
-    } catch (err) {
-      const message = await extractErrorMessage(
-        err,
-        "Failed to validate credentials",
-      );
-      setCredentialsError(message);
-      setCredentialsStatus("error");
-    } finally {
-      setCredentialsSaving(false);
-    }
-  };
-
   const MAX_VMS = 10;
   const tooManyVMs = selectedVMIds.length > MAX_VMS;
 
   const hasVMsSelected = selectedVMIds.length > 0;
 
+  const areCredentialsValid =
+    vcenterUrl.trim() !== "" &&
+    username.trim() !== "" &&
+    password.trim() !== "";
+
   const canConfigure =
     vddkStatus === "configured" &&
-    credentialsStatus === "configured" &&
+    areCredentialsValid &&
     (!hasVMsSelected || !tooManyVMs);
 
   const isInspectorRunning = async (): Promise<boolean> => {
     try {
       const status = await agentApi.getInspectorStatus({});
-      return status.state === "running" || status.state === "Initiating";
+      return status.state === "running";
     } catch {
       // Can't determine state — assume it may be running so the caller
       // attempts a stop, which is harmless if it's already stopped.
@@ -322,7 +282,14 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
       }
 
       await agentApi.startInspection({
-        startInspectionRequest: { vmIds: selectedVMIds },
+        startInspectionRequest: {
+          vmIds: selectedVMIds,
+          credentials: {
+            url: vcenterUrl.trim(),
+            username: username.trim(),
+            password: password,
+          },
+        },
       });
       onInspectionStarted();
       handleClose();
@@ -501,11 +468,7 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
 
         {/* Credentials Section */}
         <div className={modalStyles.section}>
-          <button
-            type="button"
-            className={modalStyles.sectionHeader}
-            onClick={() => setCredentialsExpanded(!credentialsExpanded)}
-          >
+          <div className={modalStyles.sectionHeader}>
             <div className={modalStyles.sectionHeaderLeft}>
               <Icon>
                 <InfoCircleIcon color="var(--pf-t--global--icon--color--status--info--default)" />
@@ -517,90 +480,40 @@ export const DeepInspectionModal: React.FC<DeepInspectionModalProps> = ({
                 </Content>
               </div>
             </div>
-            <div className={modalStyles.sectionHeaderRight}>
-              {renderSectionStatus(credentialsStatus)}
-              <AngleRightIcon
-                style={{
-                  transition: "transform 0.2s",
-                  transform: credentialsExpanded
-                    ? "rotate(90deg)"
-                    : "rotate(0deg)",
-                }}
-              />
-            </div>
-          </button>
+          </div>
 
-          {credentialsExpanded && (
-            <div className={modalStyles.sectionBody}>
-              {credentialsError && (
-                <Alert
-                  variant="danger"
-                  title="Credentials error"
-                  isInline
-                  style={{ marginBottom: "12px" }}
-                >
-                  {credentialsError}
-                </Alert>
-              )}
-
-              <Form>
-                <FormGroup
-                  label="vCenter server"
-                  isRequired
-                  fieldId="vcenter-url"
-                >
-                  <TextInput
-                    id="vcenter-url"
-                    value={vcenterUrl}
-                    onChange={(_ev, val) => {
-                      setVcenterUrl(val);
-                      if (credentialsStatus === "configured")
-                        setCredentialsStatus("notConfigured");
-                    }}
-                    placeholder="vcenter.example.com"
-                    isDisabled={credentialsSaving}
-                  />
-                </FormGroup>
-                <FormGroup label="Username" isRequired fieldId="vcenter-user">
-                  <TextInput
-                    id="vcenter-user"
-                    value={username}
-                    onChange={(_ev, val) => {
-                      setUsername(val);
-                      if (credentialsStatus === "configured")
-                        setCredentialsStatus("notConfigured");
-                    }}
-                    placeholder="administrator@vsphere.local"
-                    isDisabled={credentialsSaving}
-                  />
-                </FormGroup>
-                <FormGroup label="Password" isRequired fieldId="vcenter-pass">
-                  <TextInput
-                    id="vcenter-pass"
-                    type="password"
-                    value={password}
-                    onChange={(_ev, val) => {
-                      setPassword(val);
-                      if (credentialsStatus === "configured")
-                        setCredentialsStatus("notConfigured");
-                    }}
-                    isDisabled={credentialsSaving}
-                  />
-                </FormGroup>
-              </Form>
-              <Button
-                variant="secondary"
-                onClick={handleCredentialsSave}
-                isLoading={credentialsSaving}
-                isDisabled={
-                  credentialsSaving || !vcenterUrl || !username || !password
-                }
-                style={{ marginTop: "12px" }}
+          <div className={modalStyles.sectionBody}>
+            <Form>
+              <FormGroup
+                label="vCenter server"
+                isRequired
+                fieldId="vcenter-url"
               >
-                Validate credentials
-              </Button>
-            </div>
-          )}
+                <TextInput
+                  id="vcenter-url"
+                  value={vcenterUrl}
+                  onChange={(_ev, val) => setVcenterUrl(val)}
+                  placeholder="vcenter.example.com"
+                />
+              </FormGroup>
+              <FormGroup label="Username" isRequired fieldId="vcenter-user">
+                <TextInput
+                  id="vcenter-user"
+                  value={username}
+                  onChange={(_ev, val) => setUsername(val)}
+                  placeholder="administrator@vsphere.local"
+                />
+              </FormGroup>
+              <FormGroup label="Password" isRequired fieldId="vcenter-pass">
+                <TextInput
+                  id="vcenter-pass"
+                  type="password"
+                  value={password}
+                  onChange={(_ev, val) => setPassword(val)}
+                />
+              </FormGroup>
+            </Form>
+          </div>
         </div>
       </ModalBody>
       <ModalFooter>

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,7 +391,7 @@ __metadata:
   dependencies:
     "@emotion/css": "npm:^11.13.0"
     "@migration-planner-ui/ioc": "workspace:*"
-    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-e6e9d25bdc36"
+    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-d5edcd6935f2"
     "@patternfly/react-charts": "npm:^8.0.0"
     "@patternfly/react-core": "npm:^6.4.0"
     "@patternfly/react-icons": "npm:^6.4.0"
@@ -456,10 +456,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openshift-migration-advisor/agent-sdk@npm:0.12.0-e6e9d25bdc36":
-  version: 0.12.0-e6e9d25bdc36
-  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-e6e9d25bdc36"
-  checksum: 10c0/8e33e199cf7548650f590681f25a6aa887c02e61a1b5db2147ca0097eb0e256b31eccf41d64577d42cac502a5961d22432bdd3d47c43410d74a7e2a0b3eb937d
+"@openshift-migration-advisor/agent-sdk@npm:0.12.0-d5edcd6935f2":
+  version: 0.12.0-d5edcd6935f2
+  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-d5edcd6935f2"
+  checksum: 10c0/c9bc54cc6870bae466c9be999c641002e2b193010ac30c20530cfd871fc1db89f800460948982cfd0777a5cdd2872cf8787c52fad05eac05d863a8f2f505435d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Streamline the deep inspection setup by removing the two-step credential validation process. Credentials are now passed directly when starting the inspection, reducing API calls and improving user experience.

Changes:
- Remove credentials validation step (PUT /api/v1/inspector/credentials)
- Pass credentials directly in startInspection request body
- Display credentials form permanently (removed collapsible section)
- Remove "Validate credentials" button
- Enable "Configure" button based on field validation instead of API status
- Consolidate error handling to global error alert
- Clean up unused state variables (credentialsStatus, credentialsSaving, credentialsError, credentialsExpanded)

The API already supported passing credentials in the StartInspectionRequest, so this change leverages existing functionality while simplifying the UX from a two-step process to a single action.


<img width="840" height="674" alt="127 0 0 1_3001_report_tab=vms (3)" src="https://github.com/user-attachments/assets/17fc6244-dad0-4a1a-8673-f827a9391fe4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Deep inspection credentials are now always visible as a simple form (vCenter URL, username, password).
  * Credentials are submitted with the inspection start action—separate validation steps and toggles removed.
  * VDDK upload flow retained; inspector now focuses requests on VDDK data.
  * Added checks to prevent starting inspections when too many VMs are selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->