### PR TITLE
fix: solving issues in storage offload tab

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
@@ -104,6 +104,15 @@ function formatBytes(bytes: number): string {
   return `${bytes} B`;
 }
 
+function forecastPairToSelectedPair(pair: ForecastPairStatus): SelectedPair {
+  return {
+    id: pair.pairName,
+    name: pair.pairName,
+    sourceDatastore: pair.sourceDatastore,
+    targetDatastore: pair.targetDatastore,
+  };
+}
+
 function pairLabel(pair: SelectedPair): string {
   return `${pair.sourceDatastore} → ${pair.targetDatastore}`;
 }
@@ -2089,13 +2098,8 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
           // Rebuild pairs from the backend status so the UI has something
           // to display. Credentials aren't available but polling/display
           // still works without them.
-          const backendPairs: SelectedPair[] = (status.pairs ?? []).map(
-            (p) => ({
-              id: p.pairName,
-              name: p.pairName,
-              sourceDatastore: p.sourceDatastore,
-              targetDatastore: p.targetDatastore,
-            }),
+          const backendPairs = (status.pairs ?? []).map(
+            forecastPairToSelectedPair,
           );
           if (backendPairs.length > 0) setPairs(backendPairs);
 
@@ -2371,25 +2375,25 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
 
   // Redirect to the running step showing an existing benchmark's live status.
   // Used when a conflict is detected (another session already started a run).
-  const redirectToRunningBenchmark = useCallback(async () => {
+  const redirectToRunningBenchmark = useCallback(async (): Promise<boolean> => {
     try {
       const status = await getForecasterStatus(basePath);
       setForecastStatus(status);
 
       if (status.state === "running") {
-        const backendPairs: SelectedPair[] = (status.pairs ?? []).map((p) => ({
-          id: p.pairName,
-          name: p.pairName,
-          sourceDatastore: p.sourceDatastore,
-          targetDatastore: p.targetDatastore,
-        }));
+        const backendPairs = (status.pairs ?? []).map(
+          forecastPairToSelectedPair,
+        );
         if (backendPairs.length > 0) setPairs(backendPairs);
         setBenchmarkDone(false);
         wasRunningRef.current = true;
         setActiveStep("running");
+        return true;
       }
+
+      return false;
     } catch (_) {
-      // fall through — the conflict error message is already displayed
+      return false;
     }
   }, [basePath]);
 
@@ -2411,13 +2415,8 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
       const currentStatus = await getForecasterStatus(basePath);
       if (currentStatus.state === "running") {
         setForecastStatus(currentStatus);
-        const backendPairs: SelectedPair[] = (currentStatus.pairs ?? []).map(
-          (p) => ({
-            id: p.pairName,
-            name: p.pairName,
-            sourceDatastore: p.sourceDatastore,
-            targetDatastore: p.targetDatastore,
-          }),
+        const backendPairs = (currentStatus.pairs ?? []).map(
+          forecastPairToSelectedPair,
         );
         if (backendPairs.length > 0) setPairs(backendPairs);
         setBenchmarkDone(false);
@@ -2457,7 +2456,25 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
       pollRef.current = null; // clear sentinel on failure
 
       if (err instanceof ForecastConflictError) {
-        await redirectToRunningBenchmark();
+        const redirected = await redirectToRunningBenchmark();
+        if (!redirected) {
+          setForecastStatus({
+            state: "ready",
+            pairs: [
+              {
+                pairName: "conflict-error",
+                sourceDatastore: "",
+                targetDatastore: "",
+                state: "error",
+                error:
+                  "A benchmark was started by another session but is no longer running. Please try again.",
+                completedRuns: 0,
+                totalRuns: 0,
+              },
+            ],
+          });
+          setBenchmarkDone(true);
+        }
         return;
       }
 
@@ -2555,7 +2572,25 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
       wasRunningRef.current = true;
     } catch (err) {
       if (err instanceof ForecastConflictError) {
-        await redirectToRunningBenchmark();
+        const redirected = await redirectToRunningBenchmark();
+        if (!redirected) {
+          setForecastStatus({
+            state: "ready",
+            pairs: [
+              {
+                pairName: "conflict-error",
+                sourceDatastore: "",
+                targetDatastore: "",
+                state: "error",
+                error:
+                  "A benchmark was started by another session but is no longer running. Please try again.",
+                completedRuns: 0,
+                totalRuns: 0,
+              },
+            ],
+          });
+          setBenchmarkDone(true);
+        }
         return;
       }
 
@@ -2699,7 +2734,26 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
         wasRunningRef.current = true;
       } catch (err) {
         if (err instanceof ForecastConflictError) {
-          await redirectToRunningBenchmark();
+          const redirected = await redirectToRunningBenchmark();
+          if (!redirected) {
+            setForecastStatus((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    pairs: (prev.pairs ?? []).map((p) =>
+                      p.pairName === pair.pairName
+                        ? {
+                            ...p,
+                            state: "error" as const,
+                            error:
+                              "A benchmark was started by another session but is no longer running. Please try again.",
+                          }
+                        : p,
+                    ),
+                  }
+                : prev,
+            );
+          }
           return;
         }
 

--- a/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
@@ -2492,8 +2492,10 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
       setBenchmarkDone(false);
       wasRunningRef.current = false;
 
-      const rerunPair = pairs.find((p) => p.name === pair.pairName) ?? {
-        id: pair.pairName,
+      // Always use the datastores from the ForecastPairStatus (the actual
+      // pair that ran), never from the mutable UI `pairs` selection state
+      // which may have been edited since the benchmark started.
+      const rerunPair = {
         name: pair.pairName,
         sourceDatastore: pair.sourceDatastore,
         targetDatastore: pair.targetDatastore,
@@ -2551,10 +2553,6 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
         return;
       }
 
-      const pairNames = pairs
-        .filter((p) => p.sourceDatastore && p.targetDatastore)
-        .map((p) => p.name);
-
       const poll = async () => {
         try {
           const status = await getForecasterStatus(basePath);
@@ -2565,6 +2563,7 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
           if (wasRunningRef.current && status.state === "ready") {
             stopPolling();
             setBenchmarkDone(true);
+            const pairNames = (status.pairs ?? []).map((p) => p.pairName);
             await loadResults(pairNames);
           }
         } catch (_) {
@@ -2575,7 +2574,7 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
       poll();
       pollRef.current = setInterval(poll, 2000);
     },
-    [basePath, credentials, pairs, stopPolling, loadResults],
+    [basePath, credentials, stopPolling, loadResults],
   );
 
   const canGoToStep2 =

--- a/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
@@ -54,6 +54,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   CredentialsForbiddenError,
   cancelForecastPair,
+  ForecastConflictError,
   getForecasterStatus,
   getPairCapabilities,
   getRuns,
@@ -1745,13 +1746,35 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                             title="No results yet"
                             isInline
                             actionLinks={
-                              <Button
-                                variant="link"
-                                isInline
-                                onClick={onRefresh}
-                              >
-                                Refresh results
-                              </Button>
+                              <>
+                                <Button
+                                  variant="link"
+                                  isInline
+                                  onClick={onRefresh}
+                                >
+                                  Refresh results
+                                </Button>
+                                {onRerun &&
+                                  benchmarkDone &&
+                                  forecastStatus?.state !== "running" && (
+                                    <Button
+                                      variant="link"
+                                      isInline
+                                      onClick={() =>
+                                        onRerun({
+                                          pairName: p.name,
+                                          sourceDatastore: p.sourceDatastore,
+                                          targetDatastore: p.targetDatastore,
+                                          state: "error",
+                                          completedRuns: 0,
+                                          totalRuns: 0,
+                                        })
+                                      }
+                                    >
+                                      Re-run benchmark
+                                    </Button>
+                                  )}
+                              </>
                             }
                           >
                             No estimation runs found for this pair.
@@ -2346,6 +2369,30 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
     pollRef.current = setInterval(poll, 2000);
   }, [activeStep, benchmarkDone, basePath, pairs, stopPolling, loadResults]);
 
+  // Redirect to the running step showing an existing benchmark's live status.
+  // Used when a conflict is detected (another session already started a run).
+  const redirectToRunningBenchmark = useCallback(async () => {
+    try {
+      const status = await getForecasterStatus(basePath);
+      setForecastStatus(status);
+
+      if (status.state === "running") {
+        const backendPairs: SelectedPair[] = (status.pairs ?? []).map((p) => ({
+          id: p.pairName,
+          name: p.pairName,
+          sourceDatastore: p.sourceDatastore,
+          targetDatastore: p.targetDatastore,
+        }));
+        if (backendPairs.length > 0) setPairs(backendPairs);
+        setBenchmarkDone(false);
+        wasRunningRef.current = true;
+        setActiveStep("running");
+      }
+    } catch (_) {
+      // fall through — the conflict error message is already displayed
+    }
+  }, [basePath]);
+
   // ── Step 2 → Step 3: start benchmark ──
   const handleStartBenchmark = useCallback(async () => {
     const validPairs = pairs.filter(
@@ -2356,6 +2403,33 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
       return;
     }
     setDsError(null);
+
+    // Pre-flight: check if another session already started a benchmark.
+    // Avoids the jarring flash of switching to "running" only to immediately
+    // get a 409 and redirect.
+    try {
+      const currentStatus = await getForecasterStatus(basePath);
+      if (currentStatus.state === "running") {
+        setForecastStatus(currentStatus);
+        const backendPairs: SelectedPair[] = (currentStatus.pairs ?? []).map(
+          (p) => ({
+            id: p.pairName,
+            name: p.pairName,
+            sourceDatastore: p.sourceDatastore,
+            targetDatastore: p.targetDatastore,
+          }),
+        );
+        if (backendPairs.length > 0) setPairs(backendPairs);
+        setBenchmarkDone(false);
+        wasRunningRef.current = true;
+        setActiveStep("running");
+        return;
+      }
+    } catch (_) {
+      // If the status check fails, proceed with the start attempt anyway;
+      // the server will reject with 409 if needed.
+    }
+
     setForecastStatus(null);
     setBenchmarkDone(false);
     wasRunningRef.current = false;
@@ -2381,7 +2455,12 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
       wasRunningRef.current = true;
     } catch (err) {
       pollRef.current = null; // clear sentinel on failure
-      // If startForecast itself fails, show an error status and stop
+
+      if (err instanceof ForecastConflictError) {
+        await redirectToRunningBenchmark();
+        return;
+      }
+
       setForecastStatus({
         state: "ready",
         pairs: [
@@ -2427,7 +2506,14 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
     pollRef.current = null;
     poll();
     pollRef.current = setInterval(poll, 2000);
-  }, [basePath, credentials, pairs, stopPolling, loadResults]);
+  }, [
+    basePath,
+    credentials,
+    pairs,
+    stopPolling,
+    loadResults,
+    redirectToRunningBenchmark,
+  ]);
 
   const closeAddPairsModal = useCallback(() => {
     setIsAddPairsModalOpen(false);
@@ -2468,6 +2554,11 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
       });
       wasRunningRef.current = true;
     } catch (err) {
+      if (err instanceof ForecastConflictError) {
+        await redirectToRunningBenchmark();
+        return;
+      }
+
       setForecastStatus({
         state: "ready",
         pairs: [
@@ -2528,6 +2619,7 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
     closeAddPairsModal,
     stopPolling,
     loadResults,
+    redirectToRunningBenchmark,
   ]);
 
   // ── Cancel benchmark ──
@@ -2606,6 +2698,11 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
         });
         wasRunningRef.current = true;
       } catch (err) {
+        if (err instanceof ForecastConflictError) {
+          await redirectToRunningBenchmark();
+          return;
+        }
+
         setForecastStatus((prev) =>
           prev
             ? {
@@ -2646,7 +2743,13 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
       poll();
       pollRef.current = setInterval(poll, 2000);
     },
-    [basePath, credentials, stopPolling, loadResults],
+    [
+      basePath,
+      credentials,
+      stopPolling,
+      loadResults,
+      redirectToRunningBenchmark,
+    ],
   );
 
   const canGoToStep2 =

--- a/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
@@ -2045,6 +2045,78 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
     return () => stopPolling();
   }, [stopPolling]);
 
+  // On mount (fresh browser session, new tab, etc.), probe the backend to
+  // detect an already-running or recently-completed benchmark. sessionStorage
+  // is tab-scoped, so a new tab/session has no saved state. Without this
+  // probe the estimator would reset to the credentials step even if the
+  // forecaster is actively running on the server.
+  const hadSavedSession = useRef(!!_saved.activeStep);
+  useEffect(() => {
+    // Only act when no session was restored (i.e. truly fresh load)
+    if (hadSavedSession.current) return;
+
+    let cancelled = false;
+
+    const probe = async () => {
+      try {
+        const status = await getForecasterStatus(basePath);
+        if (cancelled) return;
+
+        if (status.state === "running") {
+          // Rebuild pairs from the backend status so the UI has something
+          // to display. Credentials aren't available but polling/display
+          // still works without them.
+          const backendPairs: SelectedPair[] = (status.pairs ?? []).map(
+            (p) => ({
+              id: p.pairName,
+              name: p.pairName,
+              sourceDatastore: p.sourceDatastore,
+              targetDatastore: p.targetDatastore,
+            }),
+          );
+          if (backendPairs.length > 0) setPairs(backendPairs);
+
+          setForecastStatus(status);
+          setBenchmarkDone(false);
+          wasRunningRef.current = true;
+          setActiveStep("running");
+          return;
+        }
+
+        // Forecaster is idle — check if historical runs exist
+        const runs = await getRuns(basePath);
+        if (cancelled || runs.length === 0) return;
+
+        // Derive pair names from historical runs
+        const runsByPair = new Map<string, ForecastRun>();
+        for (const r of runs) {
+          if (!runsByPair.has(r.pairName)) runsByPair.set(r.pairName, r);
+        }
+        const backendPairs: SelectedPair[] = Array.from(
+          runsByPair.entries(),
+        ).map(([name, run]) => ({
+          id: name,
+          name,
+          sourceDatastore: run.sourceDatastore,
+          targetDatastore: run.targetDatastore,
+        }));
+        setPairs(backendPairs);
+        setAllRuns(runs);
+        setBenchmarkDone(true);
+        setActiveStep("results");
+        hasAutoLoadedResultsRef.current = false;
+      } catch (_) {
+        // Forecaster may not be reachable — stay on default step
+      }
+    };
+
+    probe();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [basePath]);
+
   // Persist wizard state on every relevant change (password excluded)
   useEffect(() => {
     // Only save when we have at least a url (avoid storing empty state)

--- a/apps/agent-ui/src/pages/Report/components/forecasterApi.ts
+++ b/apps/agent-ui/src/pages/Report/components/forecasterApi.ts
@@ -44,6 +44,14 @@ export class CredentialsForbiddenError extends Error {
   }
 }
 
+/** Thrown when POST /forecaster returns 409 (benchmark already running). */
+export class ForecastConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ForecastConflictError";
+  }
+}
+
 /**
  * POST /collector — triggers the collector with vCenter credentials.
  * Throws CredentialsForbiddenError on 403.
@@ -117,6 +125,7 @@ export async function postDatastores(
  * POST /forecaster — start async benchmark for one or more datastore pairs.
  * Credentials are optional if previously provided in an earlier request.
  * Returns 202 on success.
+ * Throws ForecastConflictError on 409 (benchmark already running).
  */
 export async function startForecast(
   basePath: string,
@@ -127,6 +136,17 @@ export async function startForecast(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(request),
   });
+  if (res.status === 409) {
+    let msg =
+      "A benchmark is already running. Wait for it to finish or cancel it before starting a new one.";
+    try {
+      const body = await res.json();
+      if (body?.error) msg = body.error;
+    } catch (_) {
+      // use default message
+    }
+    throw new ForecastConflictError(msg);
+  }
   return handleResponse<ForecasterStatus>(res);
 }
 


### PR DESCRIPTION
- Fix re-run targeting wrong pair: Re-run now always uses the source/target datastores from the backend's ForecastPairStatus instead of looking them up from the mutable UI selection state, which could drift after edits or merges.
- Fix fresh session not showing in-progress benchmark: Added a mount-time probe (GET /forecaster) that fires on fresh browser sessions (no sessionStorage). If a benchmark is running, auto-navigates to the progress view; if historical runs exist, auto-navigates to results.
- Enforce singleton model across sessions: Added ForecastConflictError (HTTP 409) handling in forecasterApi.ts and a pre-flight status check + conflict catch in all three start-paths (handleStartBenchmark, handleRunFromModal, handleRerun). On conflict, redirects to the live benchmark instead of showing a cryptic error.
- Add re-run action to empty results: The "No results yet" alert now includes a "Re-run benchmark" link alongside "Refresh results" so users can retrigger without navigating back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic detection and redirection when a benchmark is already running in another session
  * New "Refresh results" button to update results view
  * "Re-run benchmark" action to re-execute individual benchmarks  
  * Pre-flight status checks prevent concurrent benchmark conflicts and improve cross-session synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->