### PR TITLE
fix: deep inspection status stuck on Running after backend completes

### DIFF
--- a/apps/agent-ui/src/main/Root.tsx
+++ b/apps/agent-ui/src/main/Root.tsx
@@ -31,6 +31,7 @@ export const getConfigurationBasePath = (): string => {
 function getConfiguredContainer(): Container {
   const agentApiConfig = new Configuration({
     basePath: getConfigurationBasePath(),
+    fetchApi: (url, init) => fetch(url, { ...init, cache: "no-store" }),
   });
   const container = new Container();
   container.register(Symbols.AgentApi, new DefaultApi(agentApiConfig));

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -73,8 +73,11 @@ export const ReportContainer: React.FC = () => {
     [agentApi],
   );
 
-  // Request ID for race condition prevention in VM fetching
+  // Separate request IDs for the initial/effect-driven fetch vs. polling refresh
+  // so that concurrent calls from different sources don't discard each other's
+  // responses.
   const vmsRequestIdRef = useRef(0);
+  const vmsRefreshIdRef = useRef(0);
 
   // VM pagination state
   const [vmsTotalCount, setVmsTotalCount] = useState(0);
@@ -384,7 +387,7 @@ export const ReportContainer: React.FC = () => {
   ]);
 
   const refreshVMs = useCallback(async () => {
-    const reqId = ++vmsRequestIdRef.current;
+    const reqId = ++vmsRefreshIdRef.current;
     try {
       const byExpression = filtersToByExpression(initialVMFilters);
       const response = await agentApi.getVMs({
@@ -393,7 +396,7 @@ export const ReportContainer: React.FC = () => {
         page: vmsPage,
         pageSize: vmsPageSize,
       });
-      if (vmsRequestIdRef.current === reqId) {
+      if (vmsRefreshIdRef.current === reqId) {
         setVmsList(response.vms || []);
         setVmsTotalCount(response.total || 0);
       }


### PR DESCRIPTION
- Bypass browser HTTP cache for all API calls by setting cache: no-store on the SDK fetch wrapper, ensuring polling always receives fresh data. 
- Also separate the request-ID counters for effect-driven fetches vs. polling refreshes so concurrent calls no longer discard each other's responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where VM refresh responses could be incorrectly discarded when multiple requests were in flight simultaneously, improving the reliability and consistency of VM data updates during refresh operations.

* **Improvements**
  * Updated request configuration to bypass browser cache settings, ensuring that fresh data is retrieved on each request rather than using cached responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->