### PR TITLE
fix: add some improvements to storage offload estimator

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
@@ -174,7 +174,7 @@ const CredentialsStep: React.FC<CredentialsStepProps> = ({
             component="small"
             style={{ color: "var(--pf-t--global--text--color--200)" }}
           >
-            Example: https://eco-vcenter-server.lab.eng.tlv2.redhat.com
+            Example: https://vcenter.example.com
           </Content>
         </FormGroup>
         <FormGroup label="Username" isRequired fieldId="vcenter-username">
@@ -189,7 +189,7 @@ const CredentialsStep: React.FC<CredentialsStepProps> = ({
             component="small"
             style={{ color: "var(--pf-t--global--text--color--200)" }}
           >
-            Example: qe-admin@ecosystem.content.vsphere
+            Example: administrator@vsphere.local
           </Content>
         </FormGroup>
         <FormGroup label="Password" isRequired fieldId="vcenter-password">
@@ -386,18 +386,6 @@ const PairRow: React.FC<PairRowProps> = ({
                   }}
                 >
                   Storage array: <strong>{datastoreArrayLabel(srcDs)}</strong>
-                </Content>
-              )}
-              {hasNoCapabilities && (
-                <Content
-                  component="small"
-                  style={{
-                    display: "block",
-                    marginTop: "4px",
-                    color: "var(--pf-t--global--color--status--danger--100)",
-                  }}
-                >
-                  Select different datastore pair with pair capabilities
                 </Content>
               )}
             </GridItem>
@@ -672,13 +660,14 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
           <Content component="p">
             <strong>{datastores.length}</strong> datastores discovered across{" "}
             <strong>{groups.length}</strong> storage array group(s).
-            {"\n"}Select one or more source/target pairs to run a storage
-            offload estimate on.
+          </Content>
+          <Content component="p">
+            Select one or more source/target pairs to run a storage
+            offload estimate on.{" "}
             <a
               href="https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.10/html-single/planning_your_migration_to_red_hat_openshift_virtualization/index#about-storage-copy-offload_vmware"
               target="_blank"
               rel="noopener noreferrer"
-              style={{ marginLeft: "0.5rem" }}
             >
               Learn more <ExternalLinkAltIcon />
             </a>
@@ -1123,10 +1112,18 @@ const RunningStep: React.FC<RunningStepProps> = ({
                             </Content>
                           )}
 
-                          {/* Active states: preparing, running, pending — show both progress bars */}
-                          {(isPreparing ||
-                            pair.state === "running" ||
-                            pair.state === "pending") && (
+                          {/* Pending state — not yet started */}
+                          {pair.state === "pending" && (
+                            <Content
+                              component="small"
+                              style={{ display: "block", fontStyle: "italic" }}
+                            >
+                              Pending
+                            </Content>
+                          )}
+
+                          {/* Active states: preparing or running — show both progress bars */}
+                          {(isPreparing || pair.state === "running") && (
                             <>
                               <Content
                                 component="small"
@@ -1739,9 +1736,16 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                                 completion. You can run again when ready.
                               </Alert>
                             )}
+                            {liveStatus.state === "pending" && (
+                              <Content
+                                component="small"
+                                style={{ display: "block", fontStyle: "italic" }}
+                              >
+                                Pending
+                              </Content>
+                            )}
                             {(isPreparing ||
-                              liveStatus.state === "running" ||
-                              liveStatus.state === "pending") && (
+                              liveStatus.state === "running") && (
                               <>
                                 <Content
                                   component="small"

--- a/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
@@ -52,7 +52,7 @@ import {
   TrashIcon,
 } from "@patternfly/react-icons";
 import type React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   CredentialsForbiddenError,
   cancelForecastPair,
@@ -112,6 +112,91 @@ function forecastPairToSelectedPair(pair: ForecastPairStatus): SelectedPair {
 function pairLabel(pair: SelectedPair): string {
   return `${pair.sourceDatastore} → ${pair.targetDatastore}`;
 }
+
+// ── Shared sub-components ─────────────────────────────────────────────────────
+
+interface PairProgressBarsProps {
+  prepProgress: number | undefined;
+  benchProgress: number;
+  isPreparing: boolean;
+  sourceDatastore: string;
+  targetDatastore: string;
+}
+
+const PairProgressBars: React.FC<PairProgressBarsProps> = ({
+  prepProgress,
+  benchProgress,
+  isPreparing,
+  sourceDatastore,
+  targetDatastore,
+}) => (
+  <>
+    <div style={{ marginTop: "12px" }}>
+      <Content component="p" style={{ fontWeight: 600, margin: "0 0 4px" }}>
+        Prepare
+      </Content>
+      <Content component="small" style={{ display: "block" }}>
+        Prepare environment for {sourceDatastore} → {targetDatastore}
+      </Content>
+      <Progress
+        value={isPreparing ? (prepProgress ?? 0) : 100}
+        size={ProgressSize.sm}
+        measureLocation="outside"
+        aria-label="Prep progress"
+      />
+    </div>
+    <div style={{ marginTop: "16px" }}>
+      <Content component="p" style={{ fontWeight: 600, margin: "0 0 4px" }}>
+        Running
+      </Content>
+      <Content component="small" style={{ display: "block" }}>
+        Benchmark progress for {sourceDatastore} → {targetDatastore}
+      </Content>
+      <Progress
+        value={isPreparing ? 0 : benchProgress}
+        size={ProgressSize.sm}
+        measureLocation="outside"
+        aria-label="Benchmark progress"
+      />
+    </div>
+  </>
+);
+
+interface TempResourcesAcknowledgementProps {
+  id: string;
+  isChecked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+const TempResourcesAcknowledgement: React.FC<
+  TempResourcesAcknowledgementProps
+> = ({ id, isChecked, onChange }) => (
+  <Alert
+    variant="warning"
+    isInline
+    title="The forecaster creates temporary virtual machines and virtual disks in your vCenter environment"
+  >
+    <Content component="p" style={{ marginBottom: "12px" }}>
+      While all resources are cleaned up automatically after benchmarking,
+      vCenter administrators should be aware of this activity.
+    </Content>
+    <Checkbox
+      id={id}
+      label="I understand temporary resources will be created in my vCenter environment."
+      isChecked={isChecked}
+      onChange={(_e, checked) => onChange(checked)}
+    />
+    <div style={{ marginTop: "8px" }}>
+      <a
+        href="https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.10/html-single/planning_your_migration_to_red_hat_openshift_virtualization/index#about-storage-copy-offload_vmware"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Learn more <ExternalLinkAltIcon />
+      </a>
+    </div>
+  </Alert>
+);
 
 // ── Sub-components ────────────────────────────────────────────────────────────
 
@@ -204,31 +289,11 @@ const CredentialsStep: React.FC<CredentialsStepProps> = ({
       </Form>
     </StackItem>
     <StackItem>
-      <Alert
-        variant="warning"
-        isInline
-        title="The forecaster creates temporary virtual machines and virtual disks in your vCenter environment"
-      >
-        <Content component="p" style={{ marginBottom: "12px" }}>
-          While all resources are cleaned up automatically after benchmarking,
-          vCenter administrators should be aware of this activity.
-        </Content>
-        <Checkbox
-          id="cred-acknowledge-temp-resources"
-          label="I understand temporary resources will be created in my vCenter environment."
-          isChecked={acknowledged}
-          onChange={(_e, checked) => onAcknowledgedChange(checked)}
-        />
-        <div style={{ marginTop: "8px" }}>
-          <a
-            href="https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.10/html-single/planning_your_migration_to_red_hat_openshift_virtualization/index#about-storage-copy-offload_vmware"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Learn more <ExternalLinkAltIcon />
-          </a>
-        </div>
-      </Alert>
+      <TempResourcesAcknowledgement
+        id="cred-acknowledge-temp-resources"
+        isChecked={acknowledged}
+        onChange={onAcknowledgedChange}
+      />
     </StackItem>
   </Stack>
 );
@@ -255,32 +320,25 @@ interface PairRowProps {
   idx: number;
   pair: SelectedPair;
   datastores: ForecasterDatastore[];
-  basePath: string;
   onChange: (idx: number, pair: SelectedPair) => void;
   onRemove: (idx: number) => void;
   canRemove: boolean;
-  onCapabilitiesChange?: (
-    pairId: string,
-    hasCapabilities: boolean | null,
-  ) => void;
+  pairCapabilities: string[] | null;
+  capsLoading: boolean;
 }
 
 const PairRow: React.FC<PairRowProps> = ({
   idx,
   pair,
   datastores,
-  basePath,
   onChange,
   onRemove,
   canRemove,
-  onCapabilitiesChange,
+  pairCapabilities,
+  capsLoading,
 }) => {
   const [isSrcOpen, setIsSrcOpen] = useState(false);
   const [isTgtOpen, setIsTgtOpen] = useState(false);
-  const [pairCapabilities, setPairCapabilities] = useState<string[] | null>(
-    null,
-  );
-  const [capsLoading, setCapsLoading] = useState(false);
 
   const srcDs = datastores.find((d) => d.name === pair.sourceDatastore) ?? null;
   const tgtDs = datastores.find((d) => d.name === pair.targetDatastore) ?? null;
@@ -290,55 +348,6 @@ const PairRow: React.FC<PairRowProps> = ({
     pairCapabilities.length === 0 &&
     !!pair.sourceDatastore &&
     !!pair.targetDatastore;
-
-  useEffect(() => {
-    if (!pair.sourceDatastore || !pair.targetDatastore) {
-      setPairCapabilities(null);
-      onCapabilitiesChange?.(pair.id, null);
-      return;
-    }
-    let cancelled = false;
-    setCapsLoading(true);
-    getPairCapabilities(basePath, {
-      pairs: [
-        {
-          name: pair.name,
-          sourceDatastore: pair.sourceDatastore,
-          targetDatastore: pair.targetDatastore,
-        },
-      ],
-    })
-      .then((result) => {
-        if (cancelled) return;
-        const cap = result.find(
-          (c) =>
-            c.sourceDatastore === pair.sourceDatastore &&
-            c.targetDatastore === pair.targetDatastore,
-        );
-        const caps = cap?.capabilities ?? [];
-        setPairCapabilities(caps);
-        onCapabilitiesChange?.(pair.id, caps.length > 0);
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setPairCapabilities(null);
-          onCapabilitiesChange?.(pair.id, null);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) setCapsLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    basePath,
-    pair.id,
-    pair.name,
-    pair.sourceDatastore,
-    pair.targetDatastore,
-    onCapabilitiesChange,
-  ]);
 
   const dsOptions = datastores.map((ds) => (
     <SelectOption key={ds.name} value={ds.name}>
@@ -587,24 +596,72 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
   onVmAcknowledgedChange,
 }) => {
   const showDuplicateWarning = hasDuplicateArrayRoutes(pairs, datastores);
-  const [pairCapsMap, setPairCapsMap] = useState<
-    Record<string, boolean | null>
-  >({});
 
-  const handleCapabilitiesChange = useCallback(
-    (pairId: string, hasCapabilities: boolean | null) => {
-      setPairCapsMap((prev) => ({ ...prev, [pairId]: hasCapabilities }));
-    },
-    [],
+  // Capabilities per pair: string[] (resolved), null (pending/error), or undefined (incomplete pair)
+  const [pairCapsMap, setPairCapsMap] = useState<
+    Record<string, string[] | null>
+  >({});
+  const [capsLoading, setCapsLoading] = useState(false);
+
+  const completePairs = useMemo(
+    () => pairs.filter((p) => p.sourceDatastore && p.targetDatastore),
+    [pairs],
   );
 
   useEffect(() => {
-    const completePairs = pairs.filter(
-      (p) => p.sourceDatastore && p.targetDatastore,
-    );
-    const anyNoCaps = completePairs.some((p) => pairCapsMap[p.id] === false);
+    if (completePairs.length === 0) {
+      setPairCapsMap({});
+      setCapsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setCapsLoading(true);
+
+    getPairCapabilities(basePath, {
+      pairs: completePairs.map((p) => ({
+        name: p.name,
+        sourceDatastore: p.sourceDatastore,
+        targetDatastore: p.targetDatastore,
+      })),
+    })
+      .then((results) => {
+        if (cancelled) return;
+        const next: Record<string, string[]> = {};
+        for (const p of completePairs) {
+          const cap = results.find(
+            (c) =>
+              c.sourceDatastore === p.sourceDatastore &&
+              c.targetDatastore === p.targetDatastore,
+          );
+          next[p.id] = cap?.capabilities ?? [];
+        }
+        setPairCapsMap(next);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        const next: Record<string, null> = {};
+        for (const p of completePairs) {
+          next[p.id] = null;
+        }
+        setPairCapsMap(next);
+      })
+      .finally(() => {
+        if (!cancelled) setCapsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [basePath, completePairs]);
+
+  useEffect(() => {
+    const anyNoCaps = completePairs.some((p) => {
+      const caps = pairCapsMap[p.id];
+      return caps !== null && caps !== undefined && caps.length === 0;
+    });
     onHasNoCaps?.(anyNoCaps);
-  }, [pairCapsMap, pairs, onHasNoCaps]);
+  }, [pairCapsMap, completePairs, onHasNoCaps]);
 
   const addPair = () => {
     const id = `pair-${Date.now()}`;
@@ -615,14 +672,6 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
   };
 
   const removePair = (idx: number) => {
-    const removed = pairs[idx];
-    if (removed) {
-      setPairCapsMap((prev) => {
-        const next = { ...prev };
-        delete next[removed.id];
-        return next;
-      });
-    }
     onPairsChange(pairs.filter((_, i) => i !== idx));
   };
 
@@ -662,8 +711,8 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
             <strong>{groups.length}</strong> storage array group(s).
           </Content>
           <Content component="p">
-            Select one or more source/target pairs to run a storage
-            offload estimate on.{" "}
+            Select one or more source/target pairs to run a storage offload
+            estimate on.{" "}
             <a
               href="https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.10/html-single/planning_your_migration_to_red_hat_openshift_virtualization/index#about-storage-copy-offload_vmware"
               target="_blank"
@@ -748,11 +797,13 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
             idx={idx}
             pair={pair}
             datastores={datastores}
-            basePath={basePath}
             onChange={updatePair}
             onRemove={removePair}
             canRemove={pairs.length > 1}
-            onCapabilitiesChange={handleCapabilitiesChange}
+            pairCapabilities={pairCapsMap[pair.id] ?? null}
+            capsLoading={
+              capsLoading && !!pair.sourceDatastore && !!pair.targetDatastore
+            }
           />
         ))}
         {showDuplicateWarning && (
@@ -778,32 +829,11 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
 
       {showVmWarning && (
         <StackItem>
-          <Alert
-            variant="warning"
-            isInline
-            title="The forecaster creates temporary virtual machines and virtual disks in your vCenter environment"
-          >
-            <Content component="p" style={{ marginBottom: "12px" }}>
-              While all resources are cleaned up automatically after
-              benchmarking, vCenter administrators should be aware of this
-              activity.
-            </Content>
-            <Checkbox
-              id="pairs-acknowledge-temp-resources"
-              label="I understand temporary resources will be created in my vCenter environment."
-              isChecked={vmAcknowledged}
-              onChange={(_e, checked) => onVmAcknowledgedChange?.(checked)}
-            />
-            <div style={{ marginTop: "8px" }}>
-              <a
-                href="https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.10/html-single/planning_your_migration_to_red_hat_openshift_virtualization/index#about-storage-copy-offload_vmware"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Learn more <ExternalLinkAltIcon />
-              </a>
-            </div>
-          </Alert>
+          <TempResourcesAcknowledgement
+            id="pairs-acknowledge-temp-resources"
+            isChecked={vmAcknowledged}
+            onChange={(checked) => onVmAcknowledgedChange?.(checked)}
+          />
         </StackItem>
       )}
     </Stack>
@@ -1132,60 +1162,13 @@ const RunningStep: React.FC<RunningStepProps> = ({
                                 Benchmark runs: {pair.completedRuns} /{" "}
                                 {pair.totalRuns}
                               </Content>
-
-                              {/* Prepare progress bar */}
-                              <div style={{ marginTop: "12px" }}>
-                                <Content
-                                  component="p"
-                                  style={{
-                                    fontWeight: 600,
-                                    margin: "0 0 4px",
-                                  }}
-                                >
-                                  Prepare
-                                </Content>
-                                <Content
-                                  component="small"
-                                  style={{ display: "block" }}
-                                >
-                                  Prepare environment for {pair.sourceDatastore}{" "}
-                                  → {pair.targetDatastore}
-                                </Content>
-                                <Progress
-                                  value={
-                                    isPreparing ? (prepProgress ?? 0) : 100
-                                  }
-                                  size={ProgressSize.sm}
-                                  measureLocation="outside"
-                                  aria-label="Prep progress"
-                                />
-                              </div>
-
-                              {/* Running progress bar */}
-                              <div style={{ marginTop: "16px" }}>
-                                <Content
-                                  component="p"
-                                  style={{
-                                    fontWeight: 600,
-                                    margin: "0 0 4px",
-                                  }}
-                                >
-                                  Running
-                                </Content>
-                                <Content
-                                  component="small"
-                                  style={{ display: "block" }}
-                                >
-                                  Benchmark progress for {pair.sourceDatastore}{" "}
-                                  → {pair.targetDatastore}
-                                </Content>
-                                <Progress
-                                  value={isPreparing ? 0 : benchProgress}
-                                  size={ProgressSize.sm}
-                                  measureLocation="outside"
-                                  aria-label="Benchmark progress"
-                                />
-                              </div>
+                              <PairProgressBars
+                                prepProgress={prepProgress}
+                                benchProgress={benchProgress}
+                                isPreparing={isPreparing}
+                                sourceDatastore={pair.sourceDatastore}
+                                targetDatastore={pair.targetDatastore}
+                              />
                             </>
                           )}
                         </CardBody>
@@ -1739,7 +1722,10 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                             {liveStatus.state === "pending" && (
                               <Content
                                 component="small"
-                                style={{ display: "block", fontStyle: "italic" }}
+                                style={{
+                                  display: "block",
+                                  fontStyle: "italic",
+                                }}
                               >
                                 Pending
                               </Content>
@@ -1754,60 +1740,13 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                                   Benchmark runs: {liveStatus.completedRuns} /{" "}
                                   {liveStatus.totalRuns}
                                 </Content>
-
-                                {/* Prepare progress bar */}
-                                <div style={{ marginTop: "12px" }}>
-                                  <Content
-                                    component="p"
-                                    style={{
-                                      fontWeight: 600,
-                                      margin: "0 0 4px",
-                                    }}
-                                  >
-                                    Prepare
-                                  </Content>
-                                  <Content
-                                    component="small"
-                                    style={{ display: "block" }}
-                                  >
-                                    Prepare environment for {p.sourceDatastore}{" "}
-                                    → {p.targetDatastore}
-                                  </Content>
-                                  <Progress
-                                    value={
-                                      isPreparing ? (prepProgress ?? 0) : 100
-                                    }
-                                    size={ProgressSize.sm}
-                                    measureLocation="outside"
-                                    aria-label="Prep progress"
-                                  />
-                                </div>
-
-                                {/* Running progress bar */}
-                                <div style={{ marginTop: "16px" }}>
-                                  <Content
-                                    component="p"
-                                    style={{
-                                      fontWeight: 600,
-                                      margin: "0 0 4px",
-                                    }}
-                                  >
-                                    Running
-                                  </Content>
-                                  <Content
-                                    component="small"
-                                    style={{ display: "block" }}
-                                  >
-                                    Benchmark progress for {p.sourceDatastore} →{" "}
-                                    {p.targetDatastore}
-                                  </Content>
-                                  <Progress
-                                    value={isPreparing ? 0 : benchProgress}
-                                    size={ProgressSize.sm}
-                                    measureLocation="outside"
-                                    aria-label="Benchmark progress"
-                                  />
-                                </div>
+                                <PairProgressBars
+                                  prepProgress={prepProgress}
+                                  benchProgress={benchProgress}
+                                  isPreparing={isPreparing}
+                                  sourceDatastore={p.sourceDatastore}
+                                  targetDatastore={p.targetDatastore}
+                                />
                               </>
                             )}
                             {(liveStatus.state === "canceled" ||

--- a/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
@@ -4,6 +4,7 @@ import {
   Card,
   CardBody,
   CardTitle,
+  Checkbox,
   Content,
   Dropdown,
   DropdownItem,
@@ -43,6 +44,7 @@ import {
   CheckCircleIcon,
   CopyIcon,
   EllipsisVIcon,
+  ExclamationTriangleIcon,
   ExternalLinkAltIcon,
   PlusCircleIcon,
   QuestionCircleIcon,
@@ -98,12 +100,6 @@ function groupDatastoresByArray(
   return Array.from(map.values());
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`;
-  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MB`;
-  return `${bytes} B`;
-}
-
 function forecastPairToSelectedPair(pair: ForecastPairStatus): SelectedPair {
   return {
     id: pair.pairName,
@@ -125,6 +121,8 @@ interface CredentialsStepProps {
   error: string | null;
   missingPrivileges: string[];
   isLoading: boolean;
+  acknowledged: boolean;
+  onAcknowledgedChange: (checked: boolean) => void;
 }
 
 const CredentialsStep: React.FC<CredentialsStepProps> = ({
@@ -133,6 +131,8 @@ const CredentialsStep: React.FC<CredentialsStepProps> = ({
   error,
   missingPrivileges,
   isLoading,
+  acknowledged,
+  onAcknowledgedChange,
 }) => (
   <Stack hasGutter>
     <StackItem>
@@ -170,6 +170,12 @@ const CredentialsStep: React.FC<CredentialsStepProps> = ({
             placeholder="https://vcenter.example.com"
             isDisabled={isLoading}
           />
+          <Content
+            component="small"
+            style={{ color: "var(--pf-t--global--text--color--200)" }}
+          >
+            Example: https://eco-vcenter-server.lab.eng.tlv2.redhat.com
+          </Content>
         </FormGroup>
         <FormGroup label="Username" isRequired fieldId="vcenter-username">
           <TextInput
@@ -179,6 +185,12 @@ const CredentialsStep: React.FC<CredentialsStepProps> = ({
             placeholder="administrator@vsphere.local"
             isDisabled={isLoading}
           />
+          <Content
+            component="small"
+            style={{ color: "var(--pf-t--global--text--color--200)" }}
+          >
+            Example: qe-admin@ecosystem.content.vsphere
+          </Content>
         </FormGroup>
         <FormGroup label="Password" isRequired fieldId="vcenter-password">
           <TextInput
@@ -190,6 +202,33 @@ const CredentialsStep: React.FC<CredentialsStepProps> = ({
           />
         </FormGroup>
       </Form>
+    </StackItem>
+    <StackItem>
+      <Alert
+        variant="warning"
+        isInline
+        title="The forecaster creates temporary virtual machines and virtual disks in your vCenter environment"
+      >
+        <Content component="p" style={{ marginBottom: "12px" }}>
+          While all resources are cleaned up automatically after benchmarking,
+          vCenter administrators should be aware of this activity.
+        </Content>
+        <Checkbox
+          id="cred-acknowledge-temp-resources"
+          label="I understand temporary resources will be created in my vCenter environment."
+          isChecked={acknowledged}
+          onChange={(_e, checked) => onAcknowledgedChange(checked)}
+        />
+        <div style={{ marginTop: "8px" }}>
+          <a
+            href="https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.10/html-single/planning_your_migration_to_red_hat_openshift_virtualization/index#about-storage-copy-offload_vmware"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn more <ExternalLinkAltIcon />
+          </a>
+        </div>
+      </Alert>
     </StackItem>
   </Stack>
 );
@@ -220,6 +259,10 @@ interface PairRowProps {
   onChange: (idx: number, pair: SelectedPair) => void;
   onRemove: (idx: number) => void;
   canRemove: boolean;
+  onCapabilitiesChange?: (
+    pairId: string,
+    hasCapabilities: boolean | null,
+  ) => void;
 }
 
 const PairRow: React.FC<PairRowProps> = ({
@@ -230,6 +273,7 @@ const PairRow: React.FC<PairRowProps> = ({
   onChange,
   onRemove,
   canRemove,
+  onCapabilitiesChange,
 }) => {
   const [isSrcOpen, setIsSrcOpen] = useState(false);
   const [isTgtOpen, setIsTgtOpen] = useState(false);
@@ -241,9 +285,16 @@ const PairRow: React.FC<PairRowProps> = ({
   const srcDs = datastores.find((d) => d.name === pair.sourceDatastore) ?? null;
   const tgtDs = datastores.find((d) => d.name === pair.targetDatastore) ?? null;
 
+  const hasNoCapabilities =
+    pairCapabilities !== null &&
+    pairCapabilities.length === 0 &&
+    !!pair.sourceDatastore &&
+    !!pair.targetDatastore;
+
   useEffect(() => {
     if (!pair.sourceDatastore || !pair.targetDatastore) {
       setPairCapabilities(null);
+      onCapabilitiesChange?.(pair.id, null);
       return;
     }
     let cancelled = false;
@@ -264,10 +315,15 @@ const PairRow: React.FC<PairRowProps> = ({
             c.sourceDatastore === pair.sourceDatastore &&
             c.targetDatastore === pair.targetDatastore,
         );
-        setPairCapabilities(cap?.capabilities ?? []);
+        const caps = cap?.capabilities ?? [];
+        setPairCapabilities(caps);
+        onCapabilitiesChange?.(pair.id, caps.length > 0);
       })
       .catch(() => {
-        if (!cancelled) setPairCapabilities(null);
+        if (!cancelled) {
+          setPairCapabilities(null);
+          onCapabilitiesChange?.(pair.id, null);
+        }
       })
       .finally(() => {
         if (!cancelled) setCapsLoading(false);
@@ -275,8 +331,14 @@ const PairRow: React.FC<PairRowProps> = ({
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [basePath, pair.name, pair.sourceDatastore, pair.targetDatastore]);
+  }, [
+    basePath,
+    pair.id,
+    pair.name,
+    pair.sourceDatastore,
+    pair.targetDatastore,
+    onCapabilitiesChange,
+  ]);
 
   const dsOptions = datastores.map((ds) => (
     <SelectOption key={ds.name} value={ds.name}>
@@ -306,6 +368,7 @@ const PairRow: React.FC<PairRowProps> = ({
                     isExpanded={isSrcOpen}
                     onClick={() => setIsSrcOpen((o) => !o)}
                     style={{ width: "100%" }}
+                    status={hasNoCapabilities ? "danger" : undefined}
                   >
                     {pair.sourceDatastore || "Select source datastore"}
                   </MenuToggle>
@@ -323,6 +386,18 @@ const PairRow: React.FC<PairRowProps> = ({
                   }}
                 >
                   Storage array: <strong>{datastoreArrayLabel(srcDs)}</strong>
+                </Content>
+              )}
+              {hasNoCapabilities && (
+                <Content
+                  component="small"
+                  style={{
+                    display: "block",
+                    marginTop: "4px",
+                    color: "var(--pf-t--global--color--status--danger--100)",
+                  }}
+                >
+                  Select different datastore pair with pair capabilities
                 </Content>
               )}
             </GridItem>
@@ -355,6 +430,7 @@ const PairRow: React.FC<PairRowProps> = ({
                     isExpanded={isTgtOpen}
                     onClick={() => setIsTgtOpen((o) => !o)}
                     style={{ width: "100%" }}
+                    status={hasNoCapabilities ? "danger" : undefined}
                   >
                     {pair.targetDatastore || "Select target datastore"}
                   </MenuToggle>
@@ -374,6 +450,18 @@ const PairRow: React.FC<PairRowProps> = ({
                   Storage array: <strong>{datastoreArrayLabel(tgtDs)}</strong>
                 </Content>
               )}
+              {hasNoCapabilities && (
+                <Content
+                  component="small"
+                  style={{
+                    display: "block",
+                    marginTop: "4px",
+                    color: "var(--pf-t--global--color--status--danger--100)",
+                  }}
+                >
+                  Select different datastore pair with pair capabilities
+                </Content>
+              )}
             </GridItem>
           </Grid>
 
@@ -383,7 +471,7 @@ const PairRow: React.FC<PairRowProps> = ({
               style={{
                 marginTop: "10px",
                 padding: "8px 14px",
-                border: "1px solid var(--pf-t--global--color--brand--200)",
+                border: `1px solid ${hasNoCapabilities ? "var(--pf-t--global--color--status--danger--100)" : "var(--pf-t--global--color--brand--200)"}`,
                 borderRadius: "4px",
                 background: "var(--pf-t--global--background--color--100)",
               }}
@@ -405,6 +493,12 @@ const PairRow: React.FC<PairRowProps> = ({
                     component="small"
                     style={{ fontWeight: 600, display: "block" }}
                   >
+                    {hasNoCapabilities && (
+                      <ExclamationTriangleIcon
+                        color="var(--pf-t--global--color--status--danger--100)"
+                        style={{ marginRight: "6px" }}
+                      />
+                    )}
                     Pair capabilities
                   </Content>
                   <Flex
@@ -465,6 +559,10 @@ interface SelectPairsStepProps {
   isLoading: boolean;
   error: string | null;
   basePath: string;
+  onHasNoCaps?: (hasNoCaps: boolean) => void;
+  showVmWarning?: boolean;
+  vmAcknowledged?: boolean;
+  onVmAcknowledgedChange?: (checked: boolean) => void;
 }
 
 /** Returns true when two or more complete pairs share the same source-array → target-array route. */
@@ -495,8 +593,30 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
   isLoading,
   error,
   basePath,
+  onHasNoCaps,
+  showVmWarning = false,
+  vmAcknowledged = false,
+  onVmAcknowledgedChange,
 }) => {
   const showDuplicateWarning = hasDuplicateArrayRoutes(pairs, datastores);
+  const [pairCapsMap, setPairCapsMap] = useState<
+    Record<string, boolean | null>
+  >({});
+
+  const handleCapabilitiesChange = useCallback(
+    (pairId: string, hasCapabilities: boolean | null) => {
+      setPairCapsMap((prev) => ({ ...prev, [pairId]: hasCapabilities }));
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const completePairs = pairs.filter(
+      (p) => p.sourceDatastore && p.targetDatastore,
+    );
+    const anyNoCaps = completePairs.some((p) => pairCapsMap[p.id] === false);
+    onHasNoCaps?.(anyNoCaps);
+  }, [pairCapsMap, pairs, onHasNoCaps]);
 
   const addPair = () => {
     const id = `pair-${Date.now()}`;
@@ -507,6 +627,14 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
   };
 
   const removePair = (idx: number) => {
+    const removed = pairs[idx];
+    if (removed) {
+      setPairCapsMap((prev) => {
+        const next = { ...prev };
+        delete next[removed.id];
+        return next;
+      });
+    }
     onPairsChange(pairs.filter((_, i) => i !== idx));
   };
 
@@ -544,6 +672,8 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
           <Content component="p">
             <strong>{datastores.length}</strong> datastores discovered across{" "}
             <strong>{groups.length}</strong> storage array group(s).
+            {"\n"}Select one or more source/target pairs to run a storage
+            offload estimate on.
             <a
               href="https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.10/html-single/planning_your_migration_to_red_hat_openshift_virtualization/index#about-storage-copy-offload_vmware"
               target="_blank"
@@ -633,6 +763,7 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
             onChange={updatePair}
             onRemove={removePair}
             canRemove={pairs.length > 1}
+            onCapabilitiesChange={handleCapabilitiesChange}
           />
         ))}
         {showDuplicateWarning && (
@@ -655,6 +786,37 @@ const SelectPairsStep: React.FC<SelectPairsStepProps> = ({
           Add another pair
         </Button>
       </StackItem>
+
+      {showVmWarning && (
+        <StackItem>
+          <Alert
+            variant="warning"
+            isInline
+            title="The forecaster creates temporary virtual machines and virtual disks in your vCenter environment"
+          >
+            <Content component="p" style={{ marginBottom: "12px" }}>
+              While all resources are cleaned up automatically after
+              benchmarking, vCenter administrators should be aware of this
+              activity.
+            </Content>
+            <Checkbox
+              id="pairs-acknowledge-temp-resources"
+              label="I understand temporary resources will be created in my vCenter environment."
+              isChecked={vmAcknowledged}
+              onChange={(_e, checked) => onVmAcknowledgedChange?.(checked)}
+            />
+            <div style={{ marginTop: "8px" }}>
+              <a
+                href="https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.10/html-single/planning_your_migration_to_red_hat_openshift_virtualization/index#about-storage-copy-offload_vmware"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Learn more <ExternalLinkAltIcon />
+              </a>
+            </div>
+          </Alert>
+        </StackItem>
+      )}
     </Stack>
   );
 };
@@ -961,30 +1123,11 @@ const RunningStep: React.FC<RunningStepProps> = ({
                             </Content>
                           )}
 
-                          {/* Preparing state */}
-                          {isPreparing && prepProgress !== undefined && (
-                            <div style={{ marginBottom: "12px" }}>
-                              <Content
-                                component="small"
-                                style={{ display: "block" }}
-                              >
-                                Preparing disk:{" "}
-                                {formatBytes(pair.prepBytesUploaded || 0)} /{" "}
-                                {formatBytes(pair.prepBytesTotal || 0)}
-                              </Content>
-                              <Progress
-                                value={prepProgress}
-                                size={ProgressSize.sm}
-                                measureLocation="outside"
-                                aria-label="Prep progress"
-                              />
-                            </div>
-                          )}
-
-                          {/* Running / pending: progress bar */}
-                          {(pair.state === "running" ||
+                          {/* Active states: preparing, running, pending — show both progress bars */}
+                          {(isPreparing ||
+                            pair.state === "running" ||
                             pair.state === "pending") && (
-                            <div>
+                            <>
                               <Content
                                 component="small"
                                 style={{ display: "block" }}
@@ -992,24 +1135,61 @@ const RunningStep: React.FC<RunningStepProps> = ({
                                 Benchmark runs: {pair.completedRuns} /{" "}
                                 {pair.totalRuns}
                               </Content>
-                              <Content
-                                component="small"
-                                style={{
-                                  display: "block",
-                                  marginTop: "4px",
-                                  marginBottom: "4px",
-                                }}
-                              >
-                                Benchmark progress for {pair.sourceDatastore} →{" "}
-                                {pair.targetDatastore}
-                              </Content>
-                              <Progress
-                                value={benchProgress}
-                                size={ProgressSize.sm}
-                                measureLocation="outside"
-                                aria-label="Benchmark progress"
-                              />
-                            </div>
+
+                              {/* Prepare progress bar */}
+                              <div style={{ marginTop: "12px" }}>
+                                <Content
+                                  component="p"
+                                  style={{
+                                    fontWeight: 600,
+                                    margin: "0 0 4px",
+                                  }}
+                                >
+                                  Prepare
+                                </Content>
+                                <Content
+                                  component="small"
+                                  style={{ display: "block" }}
+                                >
+                                  Prepare environment for {pair.sourceDatastore}{" "}
+                                  → {pair.targetDatastore}
+                                </Content>
+                                <Progress
+                                  value={
+                                    isPreparing ? (prepProgress ?? 0) : 100
+                                  }
+                                  size={ProgressSize.sm}
+                                  measureLocation="outside"
+                                  aria-label="Prep progress"
+                                />
+                              </div>
+
+                              {/* Running progress bar */}
+                              <div style={{ marginTop: "16px" }}>
+                                <Content
+                                  component="p"
+                                  style={{
+                                    fontWeight: 600,
+                                    margin: "0 0 4px",
+                                  }}
+                                >
+                                  Running
+                                </Content>
+                                <Content
+                                  component="small"
+                                  style={{ display: "block" }}
+                                >
+                                  Benchmark progress for {pair.sourceDatastore}{" "}
+                                  → {pair.targetDatastore}
+                                </Content>
+                                <Progress
+                                  value={isPreparing ? 0 : benchProgress}
+                                  size={ProgressSize.sm}
+                                  measureLocation="outside"
+                                  aria-label="Benchmark progress"
+                                />
+                              </div>
+                            </>
                           )}
                         </CardBody>
 
@@ -1395,8 +1575,12 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                         >
                           <FlexItem>
                             <Content
-                              component="p"
-                              style={{ fontWeight: 600, margin: 0 }}
+                              component="h3"
+                              style={{
+                                fontWeight: 600,
+                                margin: 0,
+                                fontSize: "1.15rem",
+                              }}
                             >
                               {p.sourceDatastore} → {p.targetDatastore}
                             </Content>
@@ -1555,30 +1739,10 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                                 completion. You can run again when ready.
                               </Alert>
                             )}
-                            {isPreparing && prepProgress !== undefined && (
-                              <div style={{ marginBottom: "12px" }}>
-                                <Content
-                                  component="small"
-                                  style={{ display: "block" }}
-                                >
-                                  Preparing disk:{" "}
-                                  {formatBytes(
-                                    liveStatus.prepBytesUploaded || 0,
-                                  )}{" "}
-                                  /{" "}
-                                  {formatBytes(liveStatus.prepBytesTotal || 0)}
-                                </Content>
-                                <Progress
-                                  value={prepProgress}
-                                  size={ProgressSize.sm}
-                                  measureLocation="outside"
-                                  aria-label="Prep progress"
-                                />
-                              </div>
-                            )}
-                            {(liveStatus.state === "running" ||
+                            {(isPreparing ||
+                              liveStatus.state === "running" ||
                               liveStatus.state === "pending") && (
-                              <div>
+                              <>
                                 <Content
                                   component="small"
                                   style={{ display: "block" }}
@@ -1586,24 +1750,61 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                                   Benchmark runs: {liveStatus.completedRuns} /{" "}
                                   {liveStatus.totalRuns}
                                 </Content>
-                                <Content
-                                  component="small"
-                                  style={{
-                                    display: "block",
-                                    marginTop: "4px",
-                                    marginBottom: "4px",
-                                  }}
-                                >
-                                  Benchmark progress for {p.sourceDatastore} →{" "}
-                                  {p.targetDatastore}
-                                </Content>
-                                <Progress
-                                  value={benchProgress}
-                                  size={ProgressSize.sm}
-                                  measureLocation="outside"
-                                  aria-label="Benchmark progress"
-                                />
-                              </div>
+
+                                {/* Prepare progress bar */}
+                                <div style={{ marginTop: "12px" }}>
+                                  <Content
+                                    component="p"
+                                    style={{
+                                      fontWeight: 600,
+                                      margin: "0 0 4px",
+                                    }}
+                                  >
+                                    Prepare
+                                  </Content>
+                                  <Content
+                                    component="small"
+                                    style={{ display: "block" }}
+                                  >
+                                    Prepare environment for {p.sourceDatastore}{" "}
+                                    → {p.targetDatastore}
+                                  </Content>
+                                  <Progress
+                                    value={
+                                      isPreparing ? (prepProgress ?? 0) : 100
+                                    }
+                                    size={ProgressSize.sm}
+                                    measureLocation="outside"
+                                    aria-label="Prep progress"
+                                  />
+                                </div>
+
+                                {/* Running progress bar */}
+                                <div style={{ marginTop: "16px" }}>
+                                  <Content
+                                    component="p"
+                                    style={{
+                                      fontWeight: 600,
+                                      margin: "0 0 4px",
+                                    }}
+                                  >
+                                    Running
+                                  </Content>
+                                  <Content
+                                    component="small"
+                                    style={{ display: "block" }}
+                                  >
+                                    Benchmark progress for {p.sourceDatastore} →{" "}
+                                    {p.targetDatastore}
+                                  </Content>
+                                  <Progress
+                                    value={isPreparing ? 0 : benchProgress}
+                                    size={ProgressSize.sm}
+                                    measureLocation="outside"
+                                    aria-label="Benchmark progress"
+                                  />
+                                </div>
+                              </>
                             )}
                             {(liveStatus.state === "canceled" ||
                               liveStatus.state === "error") && (
@@ -1674,11 +1875,12 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                                     )}
                                   </Content>
                                   <Content
-                                    component="small"
+                                    component="p"
                                     style={{
                                       display: "block",
+                                      fontSize: "0.95rem",
                                       color:
-                                        "var(--pf-t--global--text--color--200)",
+                                        "var(--pf-t--global--text--color--100)",
                                       marginBottom: "16px",
                                     }}
                                   >
@@ -2045,6 +2247,17 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
     null,
   );
 
+  // "I understand" checkbox state — credentials step
+  const [credAcknowledged, setCredAcknowledged] = useState(false);
+  // "I understand" checkbox state — select-pairs step
+  const [pairsVmAcknowledged, setPairsVmAcknowledged] = useState(false);
+  // "I understand" checkbox state — add-pairs modal
+  const [modalVmAcknowledged, setModalVmAcknowledged] = useState(false);
+  // Whether any complete pair has zero capabilities
+  const [pairsHaveNoCaps, setPairsHaveNoCaps] = useState(false);
+  // Whether any modal pair has zero capabilities
+  const [modalPairsHaveNoCaps, setModalPairsHaveNoCaps] = useState(false);
+
   // "Add more datastore pairs" modal
   const [isAddPairsModalOpen, setIsAddPairsModalOpen] = useState(false);
   const [modalPairs, setModalPairs] = useState<SelectedPair[]>([
@@ -2180,6 +2393,11 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
     setBenchmarkDone(false);
     setStatsMap({});
     setAllRuns([]);
+    setCredAcknowledged(false);
+    setPairsVmAcknowledged(false);
+    setModalVmAcknowledged(false);
+    setPairsHaveNoCaps(false);
+    setModalPairsHaveNoCaps(false);
   }, [stopPolling]);
 
   // ── Step 1 → Step 2: validate credentials & fetch datastores ──
@@ -2542,6 +2760,8 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
         targetDatastore: "",
       },
     ]);
+    setModalVmAcknowledged(false);
+    setModalPairsHaveNoCaps(false);
   }, []);
 
   // ── Run benchmark from "Add more datastore pairs" modal ──
@@ -2807,11 +3027,15 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
   );
 
   const canGoToStep2 =
-    !!credentials.url && !!credentials.username && !!credentials.password;
+    !!credentials.url &&
+    !!credentials.username &&
+    !!credentials.password &&
+    credAcknowledged;
 
-  const canStartBenchmark = pairs.some(
-    (p) => p.sourceDatastore && p.targetDatastore,
-  );
+  const canStartBenchmark =
+    pairs.some((p) => p.sourceDatastore && p.targetDatastore) &&
+    !pairsHaveNoCaps &&
+    pairsVmAcknowledged;
 
   // ── Step indicator ──
   const steps: { id: WizardStepId; name: string }[] = [
@@ -2826,7 +3050,7 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
     switch (activeStep) {
       case "credentials":
         return (
-          <Flex style={{ marginTop: "24px" }}>
+          <Flex style={{ marginTop: "24px" }} gap={{ default: "gapSm" }}>
             <FlexItem>
               <Button
                 variant="primary"
@@ -2835,6 +3059,20 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
                 isDisabled={!canGoToStep2 || credLoading}
               >
                 Next
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Button
+                variant="link"
+                onClick={() => {
+                  setCredentials({ url: "", username: "", password: "" });
+                  setCredError(null);
+                  setCredMissingPrivileges([]);
+                  setCredAcknowledged(false);
+                }}
+                isDisabled={credLoading}
+              >
+                Clear credentials
               </Button>
             </FlexItem>
           </Flex>
@@ -2978,6 +3216,8 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
             error={credError}
             missingPrivileges={credMissingPrivileges}
             isLoading={credLoading}
+            acknowledged={credAcknowledged}
+            onAcknowledgedChange={setCredAcknowledged}
           />
         )}
         {activeStep === "select-pairs" && (
@@ -2989,6 +3229,10 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
             isLoading={dsLoading}
             error={dsError}
             basePath={basePath}
+            onHasNoCaps={setPairsHaveNoCaps}
+            showVmWarning
+            vmAcknowledged={pairsVmAcknowledged}
+            onVmAcknowledgedChange={setPairsVmAcknowledged}
           />
         )}
         {activeStep === "running" && (
@@ -3039,6 +3283,11 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
           labelId="add-pairs-modal-title"
         />
         <ModalBody id="add-pairs-modal-body">
+          <Content component="p" style={{ marginBottom: "16px" }}>
+            Select additional source and target datastore pairs to benchmark
+            alongside your existing results. Storage array hosting and estimated
+            capabilities update when both endpoints are chosen.
+          </Content>
           <SelectPairsStep
             datastores={datastores}
             groups={dsGroups}
@@ -3047,6 +3296,10 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
             isLoading={dsLoading}
             error={null}
             basePath={basePath}
+            onHasNoCaps={setModalPairsHaveNoCaps}
+            showVmWarning
+            vmAcknowledged={modalVmAcknowledged}
+            onVmAcknowledgedChange={setModalVmAcknowledged}
           />
         </ModalBody>
         <ModalFooter>
@@ -3054,10 +3307,12 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
             variant="primary"
             onClick={handleRunFromModal}
             isDisabled={
-              !modalPairs.some((p) => p.sourceDatastore && p.targetDatastore)
+              !modalPairs.some((p) => p.sourceDatastore && p.targetDatastore) ||
+              modalPairsHaveNoCaps ||
+              !modalVmAcknowledged
             }
           >
-            Run estimation
+            Add pairs & benchmark
           </Button>
           <Button variant="link" onClick={closeAddPairsModal}>
             Cancel


### PR DESCRIPTION
1. Add warning in credentials step
2. Show error for no pair capabilities
3. Add warning in add datastore pairs
4. Double progress bar in the run benchmark step
5. Increase the size of the pair name and the time per 1TB text in the results card

[recording - 2026-05-08T115834.609.webm](https://github.com/user-attachments/assets/ebdab49b-2120-4d73-8f4c-fd7619d03121)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added acknowledgement checkboxes for temporary VM resource creation in the estimator and add-pairs modal; modal acknowledgement resets on close.
  * Per-pair capability checks now prevent starting benchmarks and disable "Add pairs & benchmark" until selections are complete, capabilities exist, and acknowledgement is checked.

* **UI Changes**
  * Progress cards now show a dedicated "Pending" label and a two-section "Prepare" / "Running" layout.
  * Pair cards use updated heading styling and stronger capability warning visuals.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/340)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->