### PR TITLE
fix: ECOPROJECT-3973 - standardize 'Cluster' terminology to distinguish between vSphere Source and OpenShift Target

### DIFF
--- a/apps/agent-ui/src/pages/Report/Header.tsx
+++ b/apps/agent-ui/src/pages/Report/Header.tsx
@@ -115,7 +115,13 @@ export const Header: React.FC<HeaderProps> = ({
               <FlexItem>
                 <Content component="p">
                   Detected <strong>{totalVMs.toLocaleString()} VMs</strong> in{" "}
-                  <strong>{totalClusters} clusters</strong>.
+                  <strong>
+                    {totalClusters}{" "}
+                    {totalClusters === 1
+                      ? "vSphere cluster"
+                      : "vSphere clusters"}
+                  </strong>
+                  .
                   {utilizationMetrics && (
                     <>
                       {" "}

--- a/apps/agent-ui/src/pages/Report/clusterView.ts
+++ b/apps/agent-ui/src/pages/Report/clusterView.ts
@@ -27,7 +27,7 @@ export const getClusterOptions = (clusters?: {
 }): ClusterOption[] => {
   const keys = clusters ? Object.keys(clusters) : [];
   return [
-    { id: "all", label: "All clusters" },
+    { id: "all", label: "All vSphere clusters" },
     ...keys.map((key) => ({ id: key, label: key })),
   ];
 };
@@ -68,7 +68,7 @@ export const buildClusterViewModel = ({
       viewClusters: clusters,
       isAggregateView: true,
       selectionId: "all",
-      selectionLabel: "All clusters",
+      selectionLabel: "All vSphere clusters",
       clusterOptions: options,
       clusterFound: true,
     };


### PR DESCRIPTION

<img width="637" height="323" alt="Captura desde 2026-05-12 07-13-25" src="https://github.com/user-attachments/assets/dd31bd68-08c1-4f04-b4fe-6a48a1f83dad" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the cluster count display to properly render singular "cluster" when one cluster is detected, and plural "clusters" for multiple, with corrected punctuation.

* **Style**
  * Updated UI labels referencing cluster selections, including the "all clusters" option, to use more specific terminology for consistency throughout the Report interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/344)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->