### PR TITLE
fix: ECOPROJECT-4608 - add warning icon in the data sharing modal title

### DIFF
--- a/apps/agent-ui/src/login-form/LoginCard.tsx
+++ b/apps/agent-ui/src/login-form/LoginCard.tsx
@@ -238,6 +238,7 @@ export const LoginCard: React.FC<LoginCardProps> = ({
       >
         <ModalHeader
           title="Confirm data sharing"
+          titleIconVariant="warning"
           labelId="data-sharing-confirm-title"
         />
         <ModalBody id="data-sharing-confirm-body">


### PR DESCRIPTION
<img width="868" height="807" alt="image" src="https://github.com/user-attachments/assets/2d6de05b-30e3-4341-9fdf-86428b892070" />
