### PR TITLE
fix: ECOPROJECT-4606 | display usage resources with decimal point

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/VMDetailsPage.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMDetailsPage.tsx
@@ -48,6 +48,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { Symbols } from "../../../main/Symbols";
+import { formatMetric } from "./VMUtilizationMetrics";
 
 const MB_IN_GB = 1024;
 
@@ -489,6 +490,7 @@ export const VMDetailsPage: React.FC<VMDetailsPageProps> = ({
                                 ) : (
                                   <Progress
                                     value={vm.utilization.cpuMax}
+                                    label={formatMetric(vm.utilization.cpuMax)}
                                     size={ProgressSize.sm}
                                     measureLocation={
                                       ProgressMeasureLocation.outside
@@ -512,6 +514,7 @@ export const VMDetailsPage: React.FC<VMDetailsPageProps> = ({
                                 ) : (
                                   <Progress
                                     value={vm.utilization.cpuAvg}
+                                    label={formatMetric(vm.utilization.cpuAvg)}
                                     size={ProgressSize.sm}
                                     measureLocation={
                                       ProgressMeasureLocation.outside
@@ -551,6 +554,7 @@ export const VMDetailsPage: React.FC<VMDetailsPageProps> = ({
                                 ) : (
                                   <Progress
                                     value={vm.utilization.memMax}
+                                    label={formatMetric(vm.utilization.memMax)}
                                     size={ProgressSize.sm}
                                     measureLocation={
                                       ProgressMeasureLocation.outside
@@ -574,6 +578,7 @@ export const VMDetailsPage: React.FC<VMDetailsPageProps> = ({
                                 ) : (
                                   <Progress
                                     value={vm.utilization.memAvg}
+                                    label={formatMetric(vm.utilization.memAvg)}
                                     size={ProgressSize.sm}
                                     measureLocation={
                                       ProgressMeasureLocation.outside
@@ -613,6 +618,7 @@ export const VMDetailsPage: React.FC<VMDetailsPageProps> = ({
                                 ) : (
                                   <Progress
                                     value={vm.utilization.disk}
+                                    label={formatMetric(vm.utilization.disk)}
                                     size={ProgressSize.sm}
                                     measureLocation={
                                       ProgressMeasureLocation.outside


### PR DESCRIPTION
<img width="764" height="267" alt="127 0 0 1_3001_report_tab=vms" src="https://github.com/user-attachments/assets/78554964-e0c9-44a2-b068-2b44dbd9ef5f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of resource metric labels in the VM Details page right-sizing section (max/avg CPU, max/avg RAM, and disk usage).
  * Labels are now clearer and more readable, aiding quick interpretation of sizing recommendations.
  * Enhances visual consistency and makes utilization comparisons easier at a glance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->