### PR TITLE
fix: ECOPROJECT-4609 - fix: incorrect cluster dropdown ordering

### DIFF
--- a/apps/agent-ui/src/pages/Report/clusterView.ts
+++ b/apps/agent-ui/src/pages/Report/clusterView.ts
@@ -26,9 +26,14 @@ export const getClusterOptions = (clusters?: {
   [key: string]: InventoryData;
 }): ClusterOption[] => {
   const keys = clusters ? Object.keys(clusters) : [];
+  const sorted = keys.sort((a, b) => {
+    const countA = clusters?.[a]?.vms?.total ?? 0;
+    const countB = clusters?.[b]?.vms?.total ?? 0;
+    return countB - countA;
+  });
   return [
     { id: "all", label: "All vSphere clusters" },
-    ...keys.map((key) => ({ id: key, label: key })),
+    ...sorted.map((key) => ({ id: key, label: key })),
   ];
 };
 


### PR DESCRIPTION
- The clusters are now sorted by vms.total in descending order.

[recording - 2026-05-13T093841.641.webm](https://github.com/user-attachments/assets/ea18f990-1884-4625-bc7e-9f059474caa3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster options in the report view are now sorted by virtual machine count in descending order, making high-capacity clusters more accessible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/348)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->