### PR TITLE
fix: use yellow instead of red for unsupported OS and non-migratable VMs

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/VMMigrationStatus.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMMigrationStatus.tsx
@@ -206,16 +206,16 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
       legendCategory: "Migratable",
     },
     {
-      name: "Unready for migration",
+      name: "Not ready for migration",
       count: data.nonMigratable,
       countDisplay: `${data.nonMigratable} VMs`,
-      legendCategory: "Unready for migration",
+      legendCategory: "Not ready for migration",
     },
   ];
 
   const legend = {
     Migratable: chartColorSuccess,
-    "Unready for migration": chartColorFailure,
+    "Not ready for migration": chartColorFailure,
   };
 
   const breakdownData = useMemo(() => {

--- a/apps/agent-ui/src/pages/Report/components/constants.ts
+++ b/apps/agent-ui/src/pages/Report/components/constants.ts
@@ -1,5 +1,5 @@
 import { chart_color_blue_300 } from "@patternfly/react-tokens/dist/esm/chart_color_blue_300";
-import { chart_color_red_orange_400 } from "@patternfly/react-tokens/dist/esm/chart_color_red_orange_400";
+import { chart_color_yellow_300 } from "@patternfly/react-tokens/dist/esm/chart_color_yellow_300";
 
 /**
  * PatternFly chart color semantics (https://www.patternfly.org/charts/colors-for-charts/design-guidelines/#best-practices):
@@ -7,4 +7,4 @@ import { chart_color_red_orange_400 } from "@patternfly/react-tokens/dist/esm/ch
  *   Red-orange → failure / non-migratable / unsupported
  */
 export const chartColorSuccess = chart_color_blue_300.value;
-export const chartColorFailure = chart_color_red_orange_400.value;
+export const chartColorFailure = chart_color_yellow_300.value;


### PR DESCRIPTION
<img width="1873" height="515" alt="Captura desde 2026-05-13 15-20-41" src="https://github.com/user-attachments/assets/624753c3-9b0d-4351-bbe8-01470b11f1a5" />
