### PR TITLE
fix: ECOPROJECT-4612 - Move the reource usage information to be more clear

### DIFF
--- a/apps/agent-ui/src/pages/Report/Header.tsx
+++ b/apps/agent-ui/src/pages/Report/Header.tsx
@@ -1,4 +1,3 @@
-import type { RightsizingClusterUtilization } from "@openshift-migration-advisor/agent-sdk";
 import {
   Button,
   Content,
@@ -20,14 +19,12 @@ import { CheckCircleIcon, ExportIcon } from "@patternfly/react-icons";
 import type React from "react";
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { VMUtilizationMetrics } from "./components/VMUtilizationMetrics";
 
 interface HeaderProps {
   totalVMs?: number;
   totalClusters?: number;
   isConnected?: boolean;
   lastUpdated?: string;
-  utilizationMetrics?: RightsizingClusterUtilization | null;
   onExport?: () => void;
   children?: ReactNode;
 }
@@ -37,7 +34,6 @@ export const Header: React.FC<HeaderProps> = ({
   totalClusters = 0,
   isConnected = true,
   lastUpdated,
-  utilizationMetrics,
   onExport,
   children,
 }) => {
@@ -99,13 +95,6 @@ export const Header: React.FC<HeaderProps> = ({
                 </Flex>
               </FlexItem>
 
-              <FlexItem>
-                <Content component="p">
-                  Presenting the information we were able to fetch from the
-                  discovery process
-                </Content>
-              </FlexItem>
-
               {lastUpdated && (
                 <FlexItem>
                   <Content component="small">{lastUpdated}</Content>
@@ -122,17 +111,6 @@ export const Header: React.FC<HeaderProps> = ({
                       : "vSphere clusters"}
                   </strong>
                   .
-                  {utilizationMetrics && (
-                    <>
-                      {" "}
-                      Total usage statistics{" "}
-                      <VMUtilizationMetrics
-                        cpu={utilizationMetrics.cpuAvg}
-                        disk={utilizationMetrics.disk}
-                        ram={utilizationMetrics.memAvg}
-                      />
-                    </>
-                  )}
                 </Content>
               </FlexItem>
             </Flex>

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -37,6 +37,7 @@ import { Symbols } from "../../main/Symbols";
 import { buildClusterViewModel, type ClusterOption } from "./clusterView";
 import { Dashboard, VirtualMachinesView } from "./components/index";
 import { StorageOffloadTab } from "./components/StorageOffloadEstimatorModal";
+import { VMUtilizationMetrics } from "./components/VMUtilizationMetrics";
 import {
   filtersToByExpression,
   hasActiveFilters,
@@ -679,7 +680,6 @@ export const ReportContainer: React.FC = () => {
             totalVMs={totalVMs}
             totalClusters={totalClusters}
             isConnected={isDataShared}
-            utilizationMetrics={utilizationMetrics}
           />
         </StackItem>
 
@@ -728,6 +728,19 @@ export const ReportContainer: React.FC = () => {
             </SelectList>
           </Select>
         </StackItem>
+
+        {utilizationMetrics && (
+          <StackItem>
+            <Content component="p">
+              Total usage statistics{" "}
+              <VMUtilizationMetrics
+                cpu={utilizationMetrics.cpuAvg}
+                disk={utilizationMetrics.disk}
+                ram={utilizationMetrics.memAvg}
+              />
+            </Content>
+          </StackItem>
+        )}
 
         {/* Tabs */}
         <StackItem>


### PR DESCRIPTION
<img width="1898" height="334" alt="image" src="https://github.com/user-attachments/assets/dec53dfa-be80-405e-bddf-69f6db94e297" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized cluster utilization metrics display on the report page, moving the "Total usage statistics" section from the header to the main content area.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/350)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->