### PR TITLE
perf: Use byExpression to filter by cluster_id on the backend

### DIFF
--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -222,7 +222,10 @@ export const ReportContainer: React.FC = () => {
 
     const fetchUtilizationMetrics = async () => {
       try {
-        const response = await agentApi.getLatestRightsizingClusters({});
+        const byExpression = `cluster_id='${selectedClusterId}'`;
+        const response = await agentApi.getLatestRightsizingClusters({
+          byExpression,
+        });
 
         // Only update state if the effect hasn't been cleaned up
         if (!cancelled) {


### PR DESCRIPTION
In order to reduce the amount of data we request to the backend, we can use the byExpression to filter by cluster_id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized cluster utilization metrics loading by targeting the currently selected cluster, improving overall performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->