### PR TITLE
fix: showing the 'Re-run benchmark' button in the 'No results' page all the time

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
@@ -2452,7 +2452,10 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
         const status = await getForecasterStatus(basePath);
         if (cancelled) return;
         setForecastStatus(status);
-        if (status.state !== "running") return;
+        if (status.state !== "running") {
+          setBenchmarkDone(true);
+          return;
+        }
 
         // A benchmark is (still) running — possibly a new one started after
         // the previous one completed. Ensure the UI shows progress cards.
@@ -2864,24 +2867,29 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
       };
 
       // Optimistically mark this pair as pending in the displayed status
-      setForecastStatus((prev) =>
-        prev
-          ? {
-              ...prev,
-              state: "running",
-              pairs: (prev.pairs ?? []).map((p) =>
+      const pendingPair: ForecastPairStatus = {
+        pairName: pair.pairName,
+        sourceDatastore: pair.sourceDatastore,
+        targetDatastore: pair.targetDatastore,
+        state: "pending" as const,
+        completedRuns: 0,
+        totalRuns: 0,
+      };
+      setForecastStatus((prev) => {
+        const base = prev ?? { state: "ready" as const, pairs: [] };
+        const existingPairs = base.pairs ?? [];
+        return {
+          ...base,
+          state: "running",
+          pairs: existingPairs.some((p) => p.pairName === pair.pairName)
+            ? existingPairs.map((p) =>
                 p.pairName === pair.pairName
-                  ? {
-                      ...p,
-                      state: "pending" as const,
-                      completedRuns: 0,
-                      error: undefined,
-                    }
+                  ? { ...p, ...pendingPair, error: undefined }
                   : p,
-              ),
-            }
-          : prev,
-      );
+              )
+            : [...existingPairs, pendingPair],
+        };
+      });
 
       try {
         await startForecast(basePath, {
@@ -2899,43 +2907,45 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
         if (err instanceof ForecastConflictError) {
           const redirected = await redirectToRunningBenchmark();
           if (!redirected) {
-            setForecastStatus((prev) =>
-              prev
-                ? {
-                    ...prev,
-                    pairs: (prev.pairs ?? []).map((p) =>
-                      p.pairName === pair.pairName
-                        ? {
-                            ...p,
-                            state: "error" as const,
-                            error:
-                              "A benchmark was started by another session but is no longer running. Please try again.",
-                          }
-                        : p,
-                    ),
-                  }
-                : prev,
-            );
-          }
-          return;
-        }
-
-        setForecastStatus((prev) =>
-          prev
-            ? {
-                ...prev,
-                pairs: (prev.pairs ?? []).map((p) =>
+            setBenchmarkDone(true);
+            setForecastStatus((prev) => {
+              const base = prev ?? { state: "ready" as const, pairs: [] };
+              return {
+                ...base,
+                state: "ready",
+                pairs: (base.pairs ?? []).map((p) =>
                   p.pairName === pair.pairName
                     ? {
                         ...p,
                         state: "error" as const,
-                        error: err instanceof Error ? err.message : String(err),
+                        error:
+                          "A benchmark was started by another session but is no longer running. Please try again.",
                       }
                     : p,
                 ),
-              }
-            : prev,
-        );
+              };
+            });
+          }
+          return;
+        }
+
+        setBenchmarkDone(true);
+        setForecastStatus((prev) => {
+          const base = prev ?? { state: "ready" as const, pairs: [] };
+          return {
+            ...base,
+            state: "ready",
+            pairs: (base.pairs ?? []).map((p) =>
+              p.pairName === pair.pairName
+                ? {
+                    ...p,
+                    state: "error" as const,
+                    error: err instanceof Error ? err.message : String(err),
+                  }
+                : p,
+            ),
+          };
+        });
         return;
       }
 


### PR DESCRIPTION
[recording - 2026-05-19T083136.358.webm](https://github.com/user-attachments/assets/c8d1e7c0-d2a1-4435-8cd0-7fcb6cba39e3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of forecast completion so results display consistently when runs finish.
  * Improved responsiveness when rerunning individual forecast pairs via optimistic UI updates and safer state merging to avoid lost updates.
  * Clearer error handling and user-facing messages for conflicts or failures when reruns cannot be started concurrently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->