### PR TITLE
fix: ECOPROJECT-4646 | Deep Inspection column incorrectly shows “0 issues” when inspection fails

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/VMDetailsPage.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMDetailsPage.tsx
@@ -270,7 +270,9 @@ export const VMDetailsPage: React.FC<VMDetailsPageProps> = ({
                           ? "Inspection in progress…"
                           : inspectionStatus.state === "canceled"
                             ? "Inspection was canceled"
-                            : "No issues found"}
+                            : inspectionStatus.state === "error"
+                              ? "Inspection failed"
+                              : "No issues found"}
                     </span>
                   )}
                 </CardBody>

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -7,6 +7,8 @@ import {
   Dropdown,
   DropdownItem,
   DropdownList,
+  Flex,
+  FlexItem,
   Label,
   LabelGroup,
   MenuToggle,
@@ -1052,7 +1054,55 @@ export const VMTable: React.FC<VMTableProps> = ({
       );
     }
 
-    if (state === "completed" || state === "error") {
+    if (state === "error") {
+      const concernCount = vm.inspectionConcernCount || 0;
+
+      if (concernCount === 0) {
+        return (
+          <Tooltip content={status.error || "Deep inspection failed"}>
+            <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+              <ExclamationCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
+              {goToDetail ? (
+                <Button variant="link" isInline onClick={goToDetail}>
+                  Error
+                </Button>
+              ) : (
+                "Error"
+              )}
+            </span>
+          </Tooltip>
+        );
+      }
+
+      return (
+        <Flex
+          alignItems={{ default: "alignItemsCenter" }}
+          spaceItems={{ default: "spaceItemsSm" }}
+        >
+          <FlexItem>
+            <Tooltip
+              content={status.error || "Deep inspection encountered an error"}
+            >
+              <ExclamationCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
+            </Tooltip>
+          </FlexItem>
+
+          <FlexItem>
+            {goToDetail ? (
+              <Button variant="link" isInline onClick={goToDetail}>
+                {`${concernCount} ${concernCount === 1 ? "issue" : "issues"}`}
+              </Button>
+            ) : (
+              <span>
+                {`${concernCount} ${concernCount === 1 ? "issue" : "issues"}`}
+              </span>
+            )}
+          </FlexItem>
+        </Flex>
+      );
+    }
+
+    if (state === "completed") {
       const concernCount = vm.inspectionConcernCount || 0;
       const label = `${concernCount} ${concernCount === 1 ? "issue" : "issues"}`;
       return goToDetail ? (


### PR DESCRIPTION
When Deep Inspection fails to retrieve data (inspectionStatus.state === "error"), the UI now correctly reflects the failure instead of displaying a misleading "0 issues".
- VMTable (Deep Inspection column):
Error with no concerns: displays a red error icon with "Error" text. Hovering shows the full error message in a tooltip. Clicking navigates to the VM detail page.
Error with partial concerns: displays a red error icon alongside the concern count (e.g., "3 issues"), with the error details available via tooltip.

- VMDetailsPage (Deep Inspection results card):
When the inspection state is "error" but no error message or concerns are available, the card now shows "Inspection failed" instead of "No issues found".


[recording - 2026-05-19T111343.822.webm](https://github.com/user-attachments/assets/c4ae196a-6fa5-4c08-8a57-b2f2e2321924)
