### PR TITLE
fix: ECOPROJECT-4615 | Selecting a datastore pair from the results list displays the statistics of a different pair.

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
@@ -917,6 +917,15 @@ const RunningStep: React.FC<RunningStepProps> = ({
                   <JumpLinksItem
                     key={pair.pairName}
                     href={`#pair-card-${pair.pairName}`}
+                    onClick={(ev) => {
+                      ev.preventDefault();
+                      document
+                        .getElementById(`pair-card-${pair.pairName}`)
+                        ?.scrollIntoView({
+                          behavior: "smooth",
+                          block: "start",
+                        });
+                    }}
                   >
                     <span
                       style={{
@@ -940,6 +949,7 @@ const RunningStep: React.FC<RunningStepProps> = ({
                 minWidth: 0,
                 maxHeight: "600px",
                 overflowY: "auto",
+                position: "relative",
               }}
             >
               <Stack hasGutter>
@@ -1427,7 +1437,19 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                   liveStatus &&
                   liveStatus.state !== "completed";
                 return (
-                  <JumpLinksItem key={p.name} href={`#result-card-${p.name}`}>
+                  <JumpLinksItem
+                    key={p.name}
+                    href={`#result-card-${p.name}`}
+                    onClick={(ev) => {
+                      ev.preventDefault();
+                      document
+                        .getElementById(`result-card-${p.name}`)
+                        ?.scrollIntoView({
+                          behavior: "smooth",
+                          block: "start",
+                        });
+                    }}
+                  >
                     <span
                       style={{
                         display: "inline-block",
@@ -1450,7 +1472,16 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                 );
               })}
               {extraRunningPairs.map((p) => (
-                <JumpLinksItem key={p.name} href={`#result-card-${p.name}`}>
+                <JumpLinksItem
+                  key={p.name}
+                  href={`#result-card-${p.name}`}
+                  onClick={(ev) => {
+                    ev.preventDefault();
+                    document
+                      .getElementById(`result-card-${p.name}`)
+                      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+                  }}
+                >
                   <span
                     style={{
                       display: "inline-block",
@@ -1477,6 +1508,7 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
               minWidth: 0,
               maxHeight: "700px",
               overflowY: "auto",
+              position: "relative",
             }}
           >
             <Stack hasGutter>


### PR DESCRIPTION
PF6's JumpLinks uses offsetTop for scroll calculations, which was incorrect due to missing positioning context and known PF6 bugs. Fixed by adding position: "relative" to the scrollable containers and adding explicit onClick handlers on each JumpLinksItem that call element.scrollIntoView({ behavior: "smooth", block: "start" }), bypassing PF6's broken scroll logic.

[recording - 2026-05-19T114316.505.webm](https://github.com/user-attachments/assets/e1b027e0-6f49-4974-ac43-c6f392982f28)
