### PR TITLE
feat: add exclude/include VMs from reports

### DIFF
--- a/apps/agent-ui/src/main/Router.tsx
+++ b/apps/agent-ui/src/main/Router.tsx
@@ -30,6 +30,39 @@ export const router = createBrowserRouter(
           Component: ProtectedReportRoute,
         };
       },
+      children: [
+        {
+          index: true,
+          element: <Navigate to="/report/vms-overview" replace />,
+        },
+        {
+          path: "vms-overview",
+          lazy: async () => {
+            const { ReportContainer } = await import(
+              "../pages/Report/ReportContainer.tsx"
+            );
+            return { Component: ReportContainer };
+          },
+        },
+        {
+          path: "groups",
+          lazy: async () => {
+            const { GroupsPage } = await import(
+              "../pages/Report/GroupsPage.tsx"
+            );
+            return { Component: GroupsPage };
+          },
+        },
+        {
+          path: "storage-offload-estimator",
+          lazy: async () => {
+            const { StorageOffloadPage } = await import(
+              "../pages/Report/StorageOffloadPage.tsx"
+            );
+            return { Component: StorageOffloadPage };
+          },
+        },
+      ],
     },
     {
       path: "/error/:code",

--- a/apps/agent-ui/src/pages/Report/GroupsPage.tsx
+++ b/apps/agent-ui/src/pages/Report/GroupsPage.tsx
@@ -1,0 +1,23 @@
+import {
+  Content,
+  EmptyState,
+  EmptyStateBody,
+  PageSection,
+} from "@patternfly/react-core";
+import type React from "react";
+
+export const GroupsPage: React.FC = () => {
+  return (
+    <PageSection hasBodyWrapper={false}>
+      <EmptyState titleText="Groups" headingLevel="h2" variant="full">
+        <EmptyStateBody>
+          <Content component="p">
+            Group management will be available here soon.
+          </Content>
+        </EmptyStateBody>
+      </EmptyState>
+    </PageSection>
+  );
+};
+
+GroupsPage.displayName = "GroupsPage";

--- a/apps/agent-ui/src/pages/Report/Header.tsx
+++ b/apps/agent-ui/src/pages/Report/Header.tsx
@@ -1,150 +1,24 @@
-import {
-  Button,
-  Content,
-  Dropdown,
-  DropdownItem,
-  DropdownList,
-  Flex,
-  FlexItem,
-  Icon,
-  MenuToggle,
-  type MenuToggleElement,
-  Split,
-  SplitItem,
-  Stack,
-  StackItem,
-  Title,
-} from "@patternfly/react-core";
-import { CheckCircleIcon, ExportIcon } from "@patternfly/react-icons";
+import { Content } from "@patternfly/react-core";
 import type React from "react";
-import type { ReactNode } from "react";
-import { useState } from "react";
 
 interface HeaderProps {
   totalVMs?: number;
   totalClusters?: number;
   isConnected?: boolean;
-  lastUpdated?: string;
-  onExport?: () => void;
-  children?: ReactNode;
 }
 
 export const Header: React.FC<HeaderProps> = ({
   totalVMs = 0,
   totalClusters = 0,
-  isConnected = true,
-  lastUpdated,
-  onExport,
-  children,
 }) => {
-  const [isExportOpen, setIsExportOpen] = useState(false);
-
-  const onExportToggle = () => {
-    setIsExportOpen(!isExportOpen);
-  };
-
   return (
-    <Stack hasGutter>
-      <StackItem>
-        <Split hasGutter>
-          <SplitItem isFilled>
-            <Flex direction={{ default: "column" }} gap={{ default: "gapSm" }}>
-              <FlexItem>
-                <Flex
-                  gap={{ default: "gapMd" }}
-                  alignItems={{ default: "alignItemsCenter" }}
-                >
-                  <FlexItem>
-                    <Title headingLevel="h1" size="2xl">
-                      Migration Advisor Report
-                    </Title>
-                  </FlexItem>
-                  <FlexItem hidden>
-                    <Button variant="link" isInline>
-                      Contact us
-                    </Button>
-                  </FlexItem>
-                </Flex>
-              </FlexItem>
-
-              <FlexItem>
-                <Flex
-                  gap={{ default: "gapSm" }}
-                  alignItems={{ default: "alignItemsCenter" }}
-                >
-                  <FlexItem>
-                    <Content component="small">
-                      <strong>Discovery VM status:</strong>
-                    </Content>
-                  </FlexItem>
-                  <FlexItem>
-                    {isConnected ? (
-                      <Flex
-                        gap={{ default: "gapXs" }}
-                        alignItems={{ default: "alignItemsCenter" }}
-                      >
-                        <Icon status="success">
-                          <CheckCircleIcon />
-                        </Icon>
-                        <Content component="small">Connected</Content>
-                      </Flex>
-                    ) : (
-                      <Content component="small">Disconnected</Content>
-                    )}
-                  </FlexItem>
-                </Flex>
-              </FlexItem>
-
-              {lastUpdated && (
-                <FlexItem>
-                  <Content component="small">{lastUpdated}</Content>
-                </FlexItem>
-              )}
-
-              <FlexItem>
-                <Content component="p">
-                  Detected <strong>{totalVMs.toLocaleString()} VMs</strong> in{" "}
-                  <strong>
-                    {totalClusters}{" "}
-                    {totalClusters === 1
-                      ? "vSphere cluster"
-                      : "vSphere clusters"}
-                  </strong>
-                  .
-                </Content>
-              </FlexItem>
-            </Flex>
-          </SplitItem>
-
-          <SplitItem hidden>
-            <Dropdown
-              isOpen={isExportOpen}
-              onSelect={() => setIsExportOpen(false)}
-              onOpenChange={setIsExportOpen}
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle
-                  ref={toggleRef}
-                  onClick={onExportToggle}
-                  isExpanded={isExportOpen}
-                  variant="secondary"
-                >
-                  <ExportIcon /> Export report
-                </MenuToggle>
-              )}
-            >
-              <DropdownList>
-                <DropdownItem key="pdf" onClick={onExport}>
-                  Export as PDF
-                </DropdownItem>
-                <DropdownItem key="csv">Export as CSV</DropdownItem>
-              </DropdownList>
-            </Dropdown>
-          </SplitItem>
-        </Split>
-      </StackItem>
-
-      {children && <StackItem>{children}</StackItem>}
-    </Stack>
+    <Content component="p">
+      Detected <strong>{totalVMs.toLocaleString()} VMs</strong> in{" "}
+      <strong>
+        {totalClusters} {totalClusters === 1 ? "cluster" : "clusters"}
+      </strong>
+      .
+    </Content>
   );
 };
 

--- a/apps/agent-ui/src/pages/Report/ProtectedReportRoute.tsx
+++ b/apps/agent-ui/src/pages/Report/ProtectedReportRoute.tsx
@@ -6,7 +6,7 @@ import { Navigate } from "react-router-dom";
 import { newAbortSignal } from "../../common/AbortSignal";
 import { REQUEST_TIMEOUT_MS } from "../../login-form/Constants";
 import { Symbols } from "../../main/Symbols";
-import ReportPage from "./ReportPage";
+import { ReportLayout } from "./ReportLayout";
 
 /**
  * Protected route wrapper for the report page.
@@ -58,8 +58,7 @@ export const ProtectedReportRoute: React.FC = () => {
     return <Navigate to="/login" replace />;
   }
 
-  // Allow access to report page
-  return <ReportPage />;
+  return <ReportLayout />;
 };
 
 ProtectedReportRoute.displayName = "ProtectedReportRoute";

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -85,6 +85,7 @@ export const ReportContainer: React.FC = () => {
   const [vmsPage, setVmsPage] = useState(1);
   const [vmsPageSize, setVmsPageSize] = useState(20);
   const [vmsSortFields, setVmsSortFields] = useState<string[]>([]);
+  const [showExcludedVMs, setShowExcludedVMs] = useState(true);
 
   // Store all available filter options (fetched once for filter UI)
   const [availableFilterOptions, setAvailableFilterOptions] = useState<{
@@ -283,17 +284,15 @@ export const ReportContainer: React.FC = () => {
     if (activeTab !== 1) return;
 
     const fetchVMs = async () => {
-      // Increment request ID and capture current value to detect stale responses
       vmsRequestIdRef.current += 1;
       const currentRequestId = vmsRequestIdRef.current;
 
       try {
         setVmsLoading(true);
 
-        // Convert filters to backend expression format
-        const byExpression = filtersToByExpression(initialVMFilters);
+        const effectiveFilters = { ...initialVMFilters, showExcludedVMs };
+        const byExpression = filtersToByExpression(effectiveFilters);
 
-        // Fetch page with backend filtering
         const response = await agentApi.getVMs({
           byExpression,
           sort: vmsSortFields.length > 0 ? vmsSortFields : undefined,
@@ -301,20 +300,17 @@ export const ReportContainer: React.FC = () => {
           pageSize: vmsPageSize,
         });
 
-        // Only update state if this is still the latest request
         if (currentRequestId === vmsRequestIdRef.current) {
           setVmsList(response.vms || []);
           setVmsTotalCount(response.total || 0);
         }
       } catch (err) {
         console.error("Error fetching VMs:", err);
-        // Only update state if this is still the latest request
         if (currentRequestId === vmsRequestIdRef.current) {
           setVmsList([]);
           setVmsTotalCount(0);
         }
       } finally {
-        // Only update loading state if this is still the latest request
         if (currentRequestId === vmsRequestIdRef.current) {
           setVmsLoading(false);
         }
@@ -326,6 +322,7 @@ export const ReportContainer: React.FC = () => {
     activeTab,
     agentApi,
     initialVMFilters,
+    showExcludedVMs,
     vmsPage,
     vmsPageSize,
     vmsSortFields,
@@ -334,7 +331,8 @@ export const ReportContainer: React.FC = () => {
   const refreshVMs = useCallback(async () => {
     const reqId = ++vmsRefreshIdRef.current;
     try {
-      const byExpression = filtersToByExpression(initialVMFilters);
+      const effectiveFilters = { ...initialVMFilters, showExcludedVMs };
+      const byExpression = filtersToByExpression(effectiveFilters);
       const response = await agentApi.getVMs({
         byExpression,
         sort: vmsSortFields.length > 0 ? vmsSortFields : undefined,
@@ -348,14 +346,21 @@ export const ReportContainer: React.FC = () => {
     } catch (err) {
       console.error("Error refreshing VMs:", err);
     }
-  }, [agentApi, initialVMFilters, vmsSortFields, vmsPage, vmsPageSize]);
+  }, [
+    agentApi,
+    initialVMFilters,
+    showExcludedVMs,
+    vmsSortFields,
+    vmsPage,
+    vmsPageSize,
+  ]);
 
   if (loading) {
     return (
       <PageSection hasBodyWrapper={false} isFilled style={{ padding: "24px" }}>
         <Stack hasGutter>
           <StackItem>
-            <Header totalVMs={0} totalClusters={0} isConnected={false} />
+            <Header totalVMs={0} totalClusters={0} />
           </StackItem>
           <StackItem>
             <Content component="p">Loading inventory data...</Content>
@@ -370,7 +375,7 @@ export const ReportContainer: React.FC = () => {
       <PageSection hasBodyWrapper={false} isFilled style={{ padding: "24px" }}>
         <Stack hasGutter>
           <StackItem>
-            <Header totalVMs={0} totalClusters={0} isConnected={false} />
+            <Header totalVMs={0} totalClusters={0} />
           </StackItem>
           <StackItem>
             <Alert variant="danger" title="Error loading inventory">
@@ -387,7 +392,7 @@ export const ReportContainer: React.FC = () => {
       <PageSection hasBodyWrapper={false} isFilled style={{ padding: "24px" }}>
         <Stack hasGutter>
           <StackItem>
-            <Header totalVMs={0} totalClusters={0} isConnected={false} />
+            <Header totalVMs={0} totalClusters={0} />
           </StackItem>
           <StackItem>
             <Alert variant="info" title="No inventory available">
@@ -618,16 +623,10 @@ export const ReportContainer: React.FC = () => {
   return (
     <PageSection hasBodyWrapper={false} isFilled style={{ padding: "24px" }}>
       <Stack hasGutter>
-        {/* Header with cluster selector */}
         <StackItem>
-          <Header
-            totalVMs={totalVMs}
-            totalClusters={totalClusters}
-            isConnected={isDataShared}
-          />
+          <Header totalVMs={totalVMs} totalClusters={totalClusters} />
         </StackItem>
 
-        {/* Data Sharing Alert - shown when not shared */}
         {!isDataShared && (
           <StackItem>
             <DataSharingAlert
@@ -689,7 +688,10 @@ export const ReportContainer: React.FC = () => {
         {/* Tabs */}
         <StackItem>
           <Tabs activeKey={activeTab} onSelect={handleTabSelect}>
-            <Tab eventKey={0} title={<TabTitleText>Overview</TabTitleText>}>
+            <Tab
+              eventKey={0}
+              title={<TabTitleText>Assessment report</TabTitleText>}
+            >
               <div style={{ marginTop: "24px" }}>
                 {clusterView.viewInfra && clusterView.viewVms ? (
                   <Dashboard
@@ -729,6 +731,11 @@ export const ReportContainer: React.FC = () => {
                   availableFilterOptions={availableFilterOptions}
                   agentApi={agentApi}
                   onRefreshVMs={refreshVMs}
+                  showExcludedVMs={showExcludedVMs}
+                  onShowExcludedVMsChange={(show) => {
+                    setShowExcludedVMs(show);
+                    setVmsPage(1);
+                  }}
                 />
               </div>
             </Tab>

--- a/apps/agent-ui/src/pages/Report/ReportLayout.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportLayout.tsx
@@ -1,0 +1,81 @@
+import {
+  Masthead,
+  MastheadBrand,
+  MastheadContent,
+  MastheadMain,
+  MastheadToggle,
+  Nav,
+  NavItem,
+  NavList,
+  Page,
+  PageSidebar,
+  PageSidebarBody,
+  PageToggleButton,
+  Title,
+} from "@patternfly/react-core";
+import { BarsIcon } from "@patternfly/react-icons";
+import type React from "react";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+
+const NAV_ITEMS = [
+  { path: "/report/vms-overview", label: "Virtual machines overview" },
+  { path: "/report/groups", label: "Groups" },
+  {
+    path: "/report/storage-offload-estimator",
+    label: "Storage offload estimator",
+  },
+] as const;
+
+export const ReportLayout: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const activeItem = NAV_ITEMS.find((item) =>
+    location.pathname.startsWith(item.path),
+  );
+
+  return (
+    <Page
+      masthead={
+        <Masthead>
+          <MastheadToggle>
+            <PageToggleButton variant="plain" aria-label="Global navigation">
+              <BarsIcon />
+            </PageToggleButton>
+          </MastheadToggle>
+          <MastheadMain>
+            <MastheadBrand>
+              <Title headingLevel="h1" size="lg">
+                Migration Advisor
+              </Title>
+            </MastheadBrand>
+          </MastheadMain>
+          <MastheadContent />
+        </Masthead>
+      }
+      sidebar={
+        <PageSidebar>
+          <PageSidebarBody>
+            <Nav aria-label="Main navigation">
+              <NavList>
+                {NAV_ITEMS.map((item) => (
+                  <NavItem
+                    key={item.path}
+                    isActive={activeItem?.path === item.path}
+                    onClick={() => navigate(item.path)}
+                  >
+                    {item.label}
+                  </NavItem>
+                ))}
+              </NavList>
+            </Nav>
+          </PageSidebarBody>
+        </PageSidebar>
+      }
+    >
+      <Outlet />
+    </Page>
+  );
+};
+
+ReportLayout.displayName = "ReportLayout";

--- a/apps/agent-ui/src/pages/Report/ReportLayout.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportLayout.tsx
@@ -36,6 +36,7 @@ export const ReportLayout: React.FC = () => {
 
   return (
     <Page
+      isManagedSidebar
       masthead={
         <Masthead>
           <MastheadToggle>

--- a/apps/agent-ui/src/pages/Report/StorageOffloadPage.tsx
+++ b/apps/agent-ui/src/pages/Report/StorageOffloadPage.tsx
@@ -1,0 +1,30 @@
+import { useInjection } from "@migration-planner-ui/ioc";
+import type { DefaultApiInterface } from "@openshift-migration-advisor/agent-sdk";
+import { PageSection } from "@patternfly/react-core";
+import type React from "react";
+import { useMemo } from "react";
+import { Symbols } from "../../main/Symbols";
+import { StorageOffloadTab } from "./components/StorageOffloadEstimatorModal";
+
+type ApiWithConfig = DefaultApiInterface & {
+  configuration?: { basePath?: string };
+};
+
+export const StorageOffloadPage: React.FC = () => {
+  const agentApi = useInjection<DefaultApiInterface>(Symbols.AgentApi);
+
+  const basePath = useMemo(
+    () =>
+      (agentApi as ApiWithConfig).configuration?.basePath ||
+      `${window.location.origin}/api/v1`,
+    [agentApi],
+  );
+
+  return (
+    <PageSection hasBodyWrapper={false} isFilled style={{ padding: "24px" }}>
+      <StorageOffloadTab basePath={basePath} />
+    </PageSection>
+  );
+};
+
+StorageOffloadPage.displayName = "StorageOffloadPage";

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -358,20 +358,30 @@ export const VMTable: React.FC<VMTableProps> = ({
   const [isIncludeModalOpen, setIsIncludeModalOpen] = useState(false);
   const [isIncludeLoading, setIsIncludeLoading] = useState(false);
 
+  const vmByIdCacheRef = useRef(new Map<string, VirtualMachine>());
+  const vmById = useMemo(() => {
+    const map = new Map(vmByIdCacheRef.current);
+    for (const vm of vms) {
+      map.set(vm.id, vm);
+    }
+    vmByIdCacheRef.current = map;
+    return map;
+  }, [vms]);
+
   const { selectedExcludedIds, selectedIncludedIds } = useMemo(() => {
     const excluded: string[] = [];
     const included: string[] = [];
-    for (const vm of vms) {
-      if (selectedVMs.has(vm.id)) {
-        if (vm.migrationExcluded) {
-          excluded.push(vm.id);
-        } else {
-          included.push(vm.id);
-        }
+    for (const id of selectedVMs) {
+      const vm = vmById.get(id);
+      if (!vm) continue;
+      if (vm.migrationExcluded) {
+        excluded.push(id);
+      } else {
+        included.push(id);
       }
     }
     return { selectedExcludedIds: excluded, selectedIncludedIds: included };
-  }, [vms, selectedVMs]);
+  }, [vmById, selectedVMs]);
 
   // Client-side filter state (applied filters)
   const [selectedStatuses, setSelectedStatuses] = useState<string[]>(
@@ -1906,9 +1916,9 @@ export const VMTable: React.FC<VMTableProps> = ({
         <ModalBody id="exclude-reports-body">
           <Content component="p">
             {(() => {
-              const names = vms
-                .filter((vm) => selectedIncludedIds.includes(vm.id))
-                .map((vm) => vm.name);
+              const names = selectedIncludedIds
+                .map((id) => vmById.get(id)?.name)
+                .filter((name): name is string => Boolean(name));
 
               if (names.length === 1) {
                 return (
@@ -1975,9 +1985,9 @@ export const VMTable: React.FC<VMTableProps> = ({
         <ModalBody id="include-reports-body">
           <Content component="p">
             {(() => {
-              const names = vms
-                .filter((vm) => selectedExcludedIds.includes(vm.id))
-                .map((vm) => vm.name);
+              const names = selectedExcludedIds
+                .map((id) => vmById.get(id)?.name)
+                .filter((name): name is string => Boolean(name));
 
               if (names.length === 1) {
                 return (

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Checkbox,
   Content,
+  Divider,
   Dropdown,
   DropdownItem,
   DropdownList,
@@ -23,6 +24,7 @@ import {
   SelectList,
   SelectOption,
   Spinner,
+  Switch,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
@@ -121,6 +123,10 @@ interface VMTableProps {
   selectedVMs?: Set<string>;
   onSelectionChange?: (selected: Set<string>) => void;
   onRunDeepInspection?: (includeVmId?: string) => void;
+  onExcludeFromReports?: (vmIds: string[]) => Promise<void>;
+  onIncludeInReports?: (vmIds: string[]) => Promise<void>;
+  showExcludedVMs?: boolean;
+  onShowExcludedVMsChange?: (show: boolean) => void;
   hasInspectionResults?: boolean;
   inspectionActive?: boolean;
   onCancelInspection?: () => void;
@@ -285,6 +291,10 @@ export const VMTable: React.FC<VMTableProps> = ({
   selectedVMs = new Set<string>(),
   onSelectionChange,
   onRunDeepInspection,
+  onExcludeFromReports,
+  onIncludeInReports,
+  showExcludedVMs = true,
+  onShowExcludedVMsChange,
   hasInspectionResults = false,
   inspectionActive = false,
   onCancelInspection,
@@ -336,9 +346,32 @@ export const VMTable: React.FC<VMTableProps> = ({
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
   const [isConcernSelectOpen, setIsConcernSelectOpen] = useState(false);
 
-  // Deep inspection kebab & cancel confirmation
-  const [isInspectionKebabOpen, setIsInspectionKebabOpen] = useState(false);
+  // Cancel deep inspection confirmation
   const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
+
+  // Bulk actions menu
+  const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
+
+  // Exclude / Include from reports modals
+  const [isExcludeModalOpen, setIsExcludeModalOpen] = useState(false);
+  const [isExcludeLoading, setIsExcludeLoading] = useState(false);
+  const [isIncludeModalOpen, setIsIncludeModalOpen] = useState(false);
+  const [isIncludeLoading, setIsIncludeLoading] = useState(false);
+
+  const { selectedExcludedIds, selectedIncludedIds } = useMemo(() => {
+    const excluded: string[] = [];
+    const included: string[] = [];
+    for (const vm of vms) {
+      if (selectedVMs.has(vm.id)) {
+        if (vm.migrationExcluded) {
+          excluded.push(vm.id);
+        } else {
+          included.push(vm.id);
+        }
+      }
+    }
+    return { selectedExcludedIds: excluded, selectedIncludedIds: included };
+  }, [vms, selectedVMs]);
 
   // Client-side filter state (applied filters)
   const [selectedStatuses, setSelectedStatuses] = useState<string[]>(
@@ -1119,6 +1152,39 @@ export const VMTable: React.FC<VMTableProps> = ({
       {/* Toolbar */}
       <Toolbar>
         <ToolbarContent>
+          {selectedVMs.size > 0 && (
+            <ToolbarItem>
+              <MenuToggle
+                variant="plainText"
+                splitButtonItems={[
+                  <Checkbox
+                    key="select-all"
+                    id="select-all-vms"
+                    isChecked={
+                      selectedVMs.size === displayVMs.length
+                        ? true
+                        : selectedVMs.size > 0
+                          ? null
+                          : false
+                    }
+                    onChange={(_event, checked) => {
+                      if (checked) {
+                        onSelectionChange?.(
+                          new Set(displayVMs.map((vm) => vm.id)),
+                        );
+                      } else {
+                        onSelectionChange?.(new Set());
+                      }
+                    }}
+                    aria-label="Select all VMs"
+                  />,
+                ]}
+              >
+                {selectedVMs.size} selected
+              </MenuToggle>
+            </ToolbarItem>
+          )}
+
           <ToolbarGroup variant="filter-group">
             <ToolbarItem>
               <SearchInput
@@ -1405,6 +1471,61 @@ export const VMTable: React.FC<VMTableProps> = ({
 
           <ToolbarGroup>
             <ToolbarItem>
+              <Dropdown
+                isOpen={isActionsMenuOpen}
+                onSelect={() => setIsActionsMenuOpen(false)}
+                onOpenChange={setIsActionsMenuOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsActionsMenuOpen(!isActionsMenuOpen)}
+                    isExpanded={isActionsMenuOpen}
+                    variant="secondary"
+                    isDisabled={selectedVMs.size === 0}
+                  >
+                    Actions
+                  </MenuToggle>
+                )}
+                popperProps={{ position: "right" }}
+              >
+                <DropdownList>
+                  {selectedIncludedIds.length > 0 && (
+                    <DropdownItem
+                      key="exclude-from-reports"
+                      onClick={() => setIsExcludeModalOpen(true)}
+                    >
+                      Exclude from reports
+                    </DropdownItem>
+                  )}
+                  {selectedExcludedIds.length > 0 && (
+                    <DropdownItem
+                      key="include-in-reports"
+                      onClick={() => setIsIncludeModalOpen(true)}
+                    >
+                      Include in reports
+                    </DropdownItem>
+                  )}
+                  <DropdownItem key="add-label">Add label</DropdownItem>
+                  <DropdownItem key="manage-labels">Manage labels</DropdownItem>
+                  <DropdownItem key="create-group">Create group</DropdownItem>
+                  <DropdownItem key="add-to-group" isDisabled>
+                    Add to group
+                  </DropdownItem>
+                  <Divider key="separator" component="li" />
+                  <DropdownItem key="remove-from-group">
+                    Remove from group
+                  </DropdownItem>
+                  <DropdownItem
+                    key="reset-deep-inspection"
+                    onClick={() => onResetInspection?.()}
+                  >
+                    Reset deep inspection
+                  </DropdownItem>
+                </DropdownList>
+              </Dropdown>
+            </ToolbarItem>
+
+            <ToolbarItem>
               <Tooltip content="Select VMs for deep inspection.">
                 <Button
                   variant="primary"
@@ -1416,62 +1537,46 @@ export const VMTable: React.FC<VMTableProps> = ({
                 </Button>
               </Tooltip>
             </ToolbarItem>
-            <ToolbarItem>
-              <Dropdown
-                isOpen={isInspectionKebabOpen}
-                onSelect={() => setIsInspectionKebabOpen(false)}
-                onOpenChange={setIsInspectionKebabOpen}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    variant="plain"
-                    onClick={() =>
-                      setIsInspectionKebabOpen(!isInspectionKebabOpen)
-                    }
-                    isExpanded={isInspectionKebabOpen}
-                  >
-                    <EllipsisVIcon />
-                  </MenuToggle>
-                )}
-                popperProps={{ position: "right" }}
-              >
-                <DropdownList>
-                  {inspectionActive && (
-                    <DropdownItem
-                      key="cancel-inspection"
-                      onClick={() => setIsCancelConfirmOpen(true)}
-                    >
-                      Cancel deep inspection
-                    </DropdownItem>
-                  )}
-                  <DropdownItem
-                    key="reset-inspection"
-                    onClick={() => onResetInspection?.()}
-                  >
-                    Reset deep inspection
-                  </DropdownItem>
-                </DropdownList>
-              </Dropdown>
-            </ToolbarItem>
             {inspectionActive && (
               <ToolbarItem>
                 <Spinner size="md" />
               </ToolbarItem>
             )}
           </ToolbarGroup>
+        </ToolbarContent>
 
-          <ToolbarItem variant="pagination" align={{ default: "alignEnd" }}>
-            <Pagination
-              itemCount={totalVMs ?? vms.length}
-              perPage={pageSize}
-              page={page}
-              onSetPage={(_event, newPage) => onPageChange?.(newPage, pageSize)}
-              onPerPageSelect={(_event, newPerPage) => {
-                onPageChange?.(1, newPerPage);
-              }}
-              variant="top"
-              isCompact
-            />
+        <ToolbarContent>
+          <ToolbarItem align={{ default: "alignEnd" }}>
+            <Flex
+              alignItems={{ default: "alignItemsCenter" }}
+              gap={{ default: "gapMd" }}
+            >
+              <FlexItem>
+                <Switch
+                  id="show-excluded-vms"
+                  label="Show excluded VMs"
+                  isChecked={showExcludedVMs}
+                  onChange={(_event, checked) =>
+                    onShowExcludedVMsChange?.(checked)
+                  }
+                />
+              </FlexItem>
+              <FlexItem>
+                <Pagination
+                  itemCount={totalVMs ?? vms.length}
+                  perPage={pageSize}
+                  page={page}
+                  onSetPage={(_event, newPage) =>
+                    onPageChange?.(newPage, pageSize)
+                  }
+                  onPerPageSelect={(_event, newPerPage) => {
+                    onPageChange?.(1, newPerPage);
+                  }}
+                  variant="top"
+                  isCompact
+                />
+              </FlexItem>
+            </Flex>
           </ToolbarItem>
         </ToolbarContent>
 
@@ -1616,6 +1721,13 @@ export const VMTable: React.FC<VMTableProps> = ({
                       <Tooltip content={vm.name}>
                         <span>{vm.name}</span>
                       </Tooltip>
+                    )}
+                    {vm.migrationExcluded && (
+                      <div style={{ marginTop: "4px" }}>
+                        <Label isCompact color="grey">
+                          Excluded
+                        </Label>
+                      </div>
                     )}
                   </Td>
                 )}
@@ -1774,6 +1886,142 @@ export const VMTable: React.FC<VMTableProps> = ({
             Confirm
           </Button>
           <Button variant="link" onClick={() => setIsCancelConfirmOpen(false)}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      {/* Exclude from reports confirmation modal */}
+      <Modal
+        isOpen={isExcludeModalOpen}
+        onClose={() => setIsExcludeModalOpen(false)}
+        aria-labelledby="exclude-reports-title"
+        aria-describedby="exclude-reports-body"
+        variant="small"
+      >
+        <ModalHeader
+          title="Exclude from reports?"
+          labelId="exclude-reports-title"
+        />
+        <ModalBody id="exclude-reports-body">
+          <Content component="p">
+            {(() => {
+              const names = vms
+                .filter((vm) => selectedIncludedIds.includes(vm.id))
+                .map((vm) => vm.name);
+
+              if (names.length === 1) {
+                return (
+                  <>
+                    <strong>{names[0]}</strong> will be excluded from all
+                    assessment reports. You can include it again from the
+                    Actions menu.
+                  </>
+                );
+              }
+
+              return (
+                <>
+                  <strong>{names.length} VMs</strong> will be excluded from all
+                  assessment reports. You can include them again from the
+                  Actions menu.
+                </>
+              );
+            })()}
+          </Content>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant="primary"
+            isLoading={isExcludeLoading}
+            isDisabled={isExcludeLoading}
+            onClick={async () => {
+              setIsExcludeLoading(true);
+              try {
+                await onExcludeFromReports?.(selectedIncludedIds);
+                setIsExcludeModalOpen(false);
+                onSelectionChange?.(new Set());
+              } catch (err) {
+                console.error("Error excluding VMs from reports:", err);
+              } finally {
+                setIsExcludeLoading(false);
+              }
+            }}
+          >
+            Exclude from reports
+          </Button>
+          <Button
+            variant="link"
+            isDisabled={isExcludeLoading}
+            onClick={() => setIsExcludeModalOpen(false)}
+          >
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      {/* Include in reports confirmation modal */}
+      <Modal
+        isOpen={isIncludeModalOpen}
+        onClose={() => setIsIncludeModalOpen(false)}
+        aria-labelledby="include-reports-title"
+        aria-describedby="include-reports-body"
+        variant="small"
+      >
+        <ModalHeader
+          title="Include in reports?"
+          labelId="include-reports-title"
+        />
+        <ModalBody id="include-reports-body">
+          <Content component="p">
+            {(() => {
+              const names = vms
+                .filter((vm) => selectedExcludedIds.includes(vm.id))
+                .map((vm) => vm.name);
+
+              if (names.length === 1) {
+                return (
+                  <>
+                    <strong>{names[0]}</strong> will be included in all
+                    assessment reports again.
+                  </>
+                );
+              }
+
+              return (
+                <>
+                  <strong>{names.length} VMs</strong> will be included in all
+                  assessment reports again.
+                </>
+              );
+            })()}
+          </Content>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant="primary"
+            isLoading={isIncludeLoading}
+            isDisabled={isIncludeLoading}
+            onClick={async () => {
+              setIsIncludeLoading(true);
+              try {
+                await onIncludeInReports?.(selectedExcludedIds);
+                setIsIncludeModalOpen(false);
+                onSelectionChange?.(new Set());
+              } catch (err) {
+                console.error("Error including VMs in reports:", err);
+              } finally {
+                setIsIncludeLoading(false);
+              }
+            }}
+          >
+            Include in reports
+          </Button>
+          <Button
+            variant="link"
+            isDisabled={isIncludeLoading}
+            onClick={() => setIsIncludeModalOpen(false)}
+          >
             Cancel
           </Button>
         </ModalFooter>

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -1499,7 +1499,7 @@ export const VMTable: React.FC<VMTableProps> = ({
                 popperProps={{ position: "right" }}
               >
                 <DropdownList>
-                  {selectedIncludedIds.length > 0 && (
+                  {onExcludeFromReports && selectedIncludedIds.length > 0 && (
                     <DropdownItem
                       key="exclude-from-reports"
                       onClick={() => setIsExcludeModalOpen(true)}
@@ -1507,7 +1507,7 @@ export const VMTable: React.FC<VMTableProps> = ({
                       Exclude from reports
                     </DropdownItem>
                   )}
-                  {selectedExcludedIds.length > 0 && (
+                  {onIncludeInReports && selectedExcludedIds.length > 0 && (
                     <DropdownItem
                       key="include-in-reports"
                       onClick={() => setIsIncludeModalOpen(true)}
@@ -1902,140 +1902,144 @@ export const VMTable: React.FC<VMTableProps> = ({
       </Modal>
 
       {/* Exclude from reports confirmation modal */}
-      <Modal
-        isOpen={isExcludeModalOpen}
-        onClose={() => setIsExcludeModalOpen(false)}
-        aria-labelledby="exclude-reports-title"
-        aria-describedby="exclude-reports-body"
-        variant="small"
-      >
-        <ModalHeader
-          title="Exclude from reports?"
-          labelId="exclude-reports-title"
-        />
-        <ModalBody id="exclude-reports-body">
-          <Content component="p">
-            {(() => {
-              const names = selectedIncludedIds
-                .map((id) => vmById.get(id)?.name)
-                .filter((name): name is string => Boolean(name));
+      {onExcludeFromReports && (
+        <Modal
+          isOpen={isExcludeModalOpen}
+          onClose={() => setIsExcludeModalOpen(false)}
+          aria-labelledby="exclude-reports-title"
+          aria-describedby="exclude-reports-body"
+          variant="small"
+        >
+          <ModalHeader
+            title="Exclude from reports?"
+            labelId="exclude-reports-title"
+          />
+          <ModalBody id="exclude-reports-body">
+            <Content component="p">
+              {(() => {
+                const names = selectedIncludedIds
+                  .map((id) => vmById.get(id)?.name)
+                  .filter((name): name is string => Boolean(name));
 
-              if (names.length === 1) {
+                if (names.length === 1) {
+                  return (
+                    <>
+                      <strong>{names[0]}</strong> will be excluded from all
+                      assessment reports. You can include it again from the
+                      Actions menu.
+                    </>
+                  );
+                }
+
                 return (
                   <>
-                    <strong>{names[0]}</strong> will be excluded from all
-                    assessment reports. You can include it again from the
+                    <strong>{names.length} VMs</strong> will be excluded from
+                    all assessment reports. You can include them again from the
                     Actions menu.
                   </>
                 );
-              }
-
-              return (
-                <>
-                  <strong>{names.length} VMs</strong> will be excluded from all
-                  assessment reports. You can include them again from the
-                  Actions menu.
-                </>
-              );
-            })()}
-          </Content>
-        </ModalBody>
-        <ModalFooter>
-          <Button
-            variant="primary"
-            isLoading={isExcludeLoading}
-            isDisabled={isExcludeLoading}
-            onClick={async () => {
-              setIsExcludeLoading(true);
-              try {
-                await onExcludeFromReports?.(selectedIncludedIds);
-                setIsExcludeModalOpen(false);
-                onSelectionChange?.(new Set());
-              } catch (err) {
-                console.error("Error excluding VMs from reports:", err);
-              } finally {
-                setIsExcludeLoading(false);
-              }
-            }}
-          >
-            Exclude from reports
-          </Button>
-          <Button
-            variant="link"
-            isDisabled={isExcludeLoading}
-            onClick={() => setIsExcludeModalOpen(false)}
-          >
-            Cancel
-          </Button>
-        </ModalFooter>
-      </Modal>
+              })()}
+            </Content>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="primary"
+              isLoading={isExcludeLoading}
+              isDisabled={isExcludeLoading}
+              onClick={async () => {
+                setIsExcludeLoading(true);
+                try {
+                  await onExcludeFromReports(selectedIncludedIds);
+                  setIsExcludeModalOpen(false);
+                  onSelectionChange?.(new Set());
+                } catch (err) {
+                  console.error("Error excluding VMs from reports:", err);
+                } finally {
+                  setIsExcludeLoading(false);
+                }
+              }}
+            >
+              Exclude from reports
+            </Button>
+            <Button
+              variant="link"
+              isDisabled={isExcludeLoading}
+              onClick={() => setIsExcludeModalOpen(false)}
+            >
+              Cancel
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
 
       {/* Include in reports confirmation modal */}
-      <Modal
-        isOpen={isIncludeModalOpen}
-        onClose={() => setIsIncludeModalOpen(false)}
-        aria-labelledby="include-reports-title"
-        aria-describedby="include-reports-body"
-        variant="small"
-      >
-        <ModalHeader
-          title="Include in reports?"
-          labelId="include-reports-title"
-        />
-        <ModalBody id="include-reports-body">
-          <Content component="p">
-            {(() => {
-              const names = selectedExcludedIds
-                .map((id) => vmById.get(id)?.name)
-                .filter((name): name is string => Boolean(name));
+      {onIncludeInReports && (
+        <Modal
+          isOpen={isIncludeModalOpen}
+          onClose={() => setIsIncludeModalOpen(false)}
+          aria-labelledby="include-reports-title"
+          aria-describedby="include-reports-body"
+          variant="small"
+        >
+          <ModalHeader
+            title="Include in reports?"
+            labelId="include-reports-title"
+          />
+          <ModalBody id="include-reports-body">
+            <Content component="p">
+              {(() => {
+                const names = selectedExcludedIds
+                  .map((id) => vmById.get(id)?.name)
+                  .filter((name): name is string => Boolean(name));
 
-              if (names.length === 1) {
+                if (names.length === 1) {
+                  return (
+                    <>
+                      <strong>{names[0]}</strong> will be included in all
+                      assessment reports again.
+                    </>
+                  );
+                }
+
                 return (
                   <>
-                    <strong>{names[0]}</strong> will be included in all
+                    <strong>{names.length} VMs</strong> will be included in all
                     assessment reports again.
                   </>
                 );
-              }
-
-              return (
-                <>
-                  <strong>{names.length} VMs</strong> will be included in all
-                  assessment reports again.
-                </>
-              );
-            })()}
-          </Content>
-        </ModalBody>
-        <ModalFooter>
-          <Button
-            variant="primary"
-            isLoading={isIncludeLoading}
-            isDisabled={isIncludeLoading}
-            onClick={async () => {
-              setIsIncludeLoading(true);
-              try {
-                await onIncludeInReports?.(selectedExcludedIds);
-                setIsIncludeModalOpen(false);
-                onSelectionChange?.(new Set());
-              } catch (err) {
-                console.error("Error including VMs in reports:", err);
-              } finally {
-                setIsIncludeLoading(false);
-              }
-            }}
-          >
-            Include in reports
-          </Button>
-          <Button
-            variant="link"
-            isDisabled={isIncludeLoading}
-            onClick={() => setIsIncludeModalOpen(false)}
-          >
-            Cancel
-          </Button>
-        </ModalFooter>
-      </Modal>
+              })()}
+            </Content>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="primary"
+              isLoading={isIncludeLoading}
+              isDisabled={isIncludeLoading}
+              onClick={async () => {
+                setIsIncludeLoading(true);
+                try {
+                  await onIncludeInReports(selectedExcludedIds);
+                  setIsIncludeModalOpen(false);
+                  onSelectionChange?.(new Set());
+                } catch (err) {
+                  console.error("Error including VMs in reports:", err);
+                } finally {
+                  setIsIncludeLoading(false);
+                }
+              }}
+            >
+              Include in reports
+            </Button>
+            <Button
+              variant="link"
+              isDisabled={isIncludeLoading}
+              onClick={() => setIsIncludeModalOpen(false)}
+            >
+              Cancel
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
     </div>
   );
 };

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -27,6 +27,8 @@ interface VirtualMachinesViewProps {
   };
   agentApi?: DefaultApiInterface;
   onRefreshVMs?: () => void;
+  showExcludedVMs?: boolean;
+  onShowExcludedVMsChange?: (show: boolean) => void;
 }
 
 export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
@@ -42,6 +44,8 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   availableFilterOptions,
   agentApi,
   onRefreshVMs,
+  showExcludedVMs,
+  onShowExcludedVMsChange,
 }) => {
   const [selectedVMId, setSelectedVMId] = useState<string | null>(null);
   const [selectedVMs, setSelectedVMs] = useState<Set<string>>(new Set());
@@ -125,6 +129,38 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
       console.error("Error canceling inspection:", err);
     }
   }, [agentApi, onRefreshVMs, stopPolling]);
+
+  const handleExcludeFromReports = useCallback(
+    async (vmIds: string[]) => {
+      if (!agentApi) return;
+      await Promise.all(
+        vmIds.map((id) =>
+          agentApi.updateVM({
+            id,
+            virtualMachineUpdateRequest: { migrationExcluded: true },
+          }),
+        ),
+      );
+      onRefreshVMs?.();
+    },
+    [agentApi, onRefreshVMs],
+  );
+
+  const handleIncludeInReports = useCallback(
+    async (vmIds: string[]) => {
+      if (!agentApi) return;
+      await Promise.all(
+        vmIds.map((id) =>
+          agentApi.updateVM({
+            id,
+            virtualMachineUpdateRequest: { migrationExcluded: false },
+          }),
+        ),
+      );
+      onRefreshVMs?.();
+    },
+    [agentApi, onRefreshVMs],
+  );
 
   const handleResetInspection = useCallback(async () => {
     if (!agentApi) return;
@@ -222,6 +258,10 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
         selectedVMs={selectedVMs}
         onSelectionChange={setSelectedVMs}
         onRunDeepInspection={handleRunDeepInspection}
+        onExcludeFromReports={handleExcludeFromReports}
+        onIncludeInReports={handleIncludeInReports}
+        showExcludedVMs={showExcludedVMs}
+        onShowExcludedVMsChange={onShowExcludedVMsChange}
         hasInspectionResults={hasInspectionResults || inspectionActive}
         inspectionActive={inspectionActive}
         onCancelInspection={handleCancelInspection}

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -9,6 +9,39 @@ import { VMDetailsPage } from "./VMDetailsPage";
 import { VMTable } from "./VMTable";
 import type { VMFilters } from "./vmFilters";
 
+async function updateVmMigrationExcluded(
+  agentApi: DefaultApiInterface,
+  vmIds: string[],
+  migrationExcluded: boolean,
+  onRefreshVMs?: () => void,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    vmIds.map((id) =>
+      agentApi.updateVM({
+        id,
+        virtualMachineUpdateRequest: { migrationExcluded },
+      }),
+    ),
+  );
+
+  const failedIds: string[] = [];
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status === "rejected") {
+      failedIds.push(vmIds[i]);
+      console.error(`Error updating VM ${vmIds[i]}:`, result.reason);
+    }
+  }
+
+  onRefreshVMs?.();
+
+  if (failedIds.length > 0) {
+    throw new Error(
+      `Failed to update ${failedIds.length} of ${vmIds.length} VM(s): ${failedIds.join(", ")}`,
+    );
+  }
+}
+
 interface VirtualMachinesViewProps {
   vms: VirtualMachine[];
   loading?: boolean;
@@ -133,15 +166,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   const handleExcludeFromReports = useCallback(
     async (vmIds: string[]) => {
       if (!agentApi) return;
-      await Promise.all(
-        vmIds.map((id) =>
-          agentApi.updateVM({
-            id,
-            virtualMachineUpdateRequest: { migrationExcluded: true },
-          }),
-        ),
-      );
-      onRefreshVMs?.();
+      await updateVmMigrationExcluded(agentApi, vmIds, true, onRefreshVMs);
     },
     [agentApi, onRefreshVMs],
   );
@@ -149,15 +174,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   const handleIncludeInReports = useCallback(
     async (vmIds: string[]) => {
       if (!agentApi) return;
-      await Promise.all(
-        vmIds.map((id) =>
-          agentApi.updateVM({
-            id,
-            virtualMachineUpdateRequest: { migrationExcluded: false },
-          }),
-        ),
-      );
-      onRefreshVMs?.();
+      await updateVmMigrationExcluded(agentApi, vmIds, false, onRefreshVMs);
     },
     [agentApi, onRefreshVMs],
   );

--- a/apps/agent-ui/src/pages/Report/components/vmFilters.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmFilters.ts
@@ -10,6 +10,7 @@ export interface VMFilters {
   migrationReadiness?: string[];
   concernLabels?: string[];
   concernCategories?: string[];
+  showExcludedVMs?: boolean;
 }
 
 /**
@@ -148,7 +149,10 @@ export function filtersToByExpression(filters: VMFilters): string | undefined {
     // If both are selected, don't add a filter (show all)
   }
 
-  // Join all conditions with AND
+  if (filters.showExcludedVMs === false) {
+    conditions.push("migration_excluded = false");
+  }
+
   if (conditions.length === 0) {
     return undefined;
   }

--- a/apps/agent-ui/src/pages/Report/index.ts
+++ b/apps/agent-ui/src/pages/Report/index.ts
@@ -1,4 +1,7 @@
+export { GroupsPage } from "./GroupsPage";
 export { Header } from "./Header";
 export { ProtectedReportRoute } from "./ProtectedReportRoute";
 export { ReportContainer } from "./ReportContainer";
+export { ReportLayout } from "./ReportLayout";
 export { default as ReportPage } from "./ReportPage";
+export { StorageOffloadPage } from "./StorageOffloadPage";


### PR DESCRIPTION
- Add ability to exclude VMs from assessment reports via the Actions toolbar menu, with an "Excluded" label shown on affected VMs.
- The Actions dropdown dynamically shows "Exclude from reports" and/or "Include in reports" based on the migrationExcluded state of selected VMs.
- A backend filter via byExpression is sent when the "Show excluded VMs" toggle is off.

[recording - 2026-05-21T115942.227.webm](https://github.com/user-attachments/assets/7b22162e-bb63-4cfb-b136-eba4442dcbfe)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk exclude/include VMs from reports with confirmation dialogs.
  * New "Groups" section (coming soon).
  * New "Storage Offload Estimator" page.
  * Toggle to show or hide excluded VMs in assessment views.
  * Nested /report routes with a dedicated report layout and sidebar navigation.

* **Improvements**
  * Simplified report header showing detected VMs and cluster count.
  * Renamed "Overview" tab to "Assessment report".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->