### PR TITLE
feat: ECOPROJECT-4377 |subset of vms labeling

### DIFF
--- a/apps/agent-ui/src/login-form/hooks/UseLoginViewModel.ts
+++ b/apps/agent-ui/src/login-form/hooks/UseLoginViewModel.ts
@@ -6,7 +6,6 @@ import type {
 } from "@openshift-migration-advisor/agent-sdk";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useTitle } from "react-use";
 import { newAbortSignal } from "../../common/AbortSignal";
 import type { ApiError } from "../../common/components/index";
 import { Symbols } from "../../main/Symbols";
@@ -32,7 +31,6 @@ interface UseLoginViewModelProps {
 export const useLoginViewModel = (
   props?: UseLoginViewModelProps,
 ): LoginViewModelInterface => {
-  useTitle("Login - Migration Discovery VM");
   const agentApi = useInjection<DefaultApiInterface>(Symbols.AgentApi);
   const navigate = useNavigate();
   const refetchAgentStatus = props?.refetchAgentStatus;

--- a/apps/agent-ui/src/pages/AgentLoginPage.tsx
+++ b/apps/agent-ui/src/pages/AgentLoginPage.tsx
@@ -1,5 +1,6 @@
 import { AgentModeRequestModeEnum } from "@openshift-migration-advisor/agent-sdk";
 import type React from "react";
+import { useEffect } from "react";
 import { useAgentStatus } from "../common/AgentStatusContext";
 import { useLoginViewModel } from "../login-form/hooks/UseLoginViewModel";
 import { LoginCard } from "../login-form/LoginCard";
@@ -7,6 +8,10 @@ import { LoginCard } from "../login-form/LoginCard";
 const AgentLoginPage: React.FC = () => {
   const { agentStatus, refetch: refetchAgentStatus } = useAgentStatus();
   const vm = useLoginViewModel({ refetchAgentStatus });
+
+  useEffect(() => {
+    document.title = "Migration Advisor";
+  }, []);
   return (
     <LoginCard
       version={vm.version}

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -332,14 +332,14 @@ export const ReportContainer: React.FC = () => {
           page: vmsPage,
           pageSize: vmsPageSize,
         }),
-        agentApi.getVMLabels().catch(() => ({ labels: [] as string[] })),
+        agentApi.getVMLabels().catch(() => null),
       ]);
       if (vmsRefreshIdRef.current === reqId) {
         setVmsList(response.vms || []);
         setVmsTotalCount(response.total || 0);
         setAvailableFilterOptions((prev) => ({
           ...prev,
-          vmLabels: labelsResponse.labels || [],
+          vmLabels: labelsResponse?.labels ?? prev.vmLabels,
         }));
       }
     } catch (err) {

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -34,9 +34,9 @@ import {
   DataSharingModal,
 } from "../../common/components/index";
 import { Symbols } from "../../main/Symbols";
+import { getAgentApiBasePath } from "./agentApiConfig";
 import { buildClusterViewModel, type ClusterOption } from "./clusterView";
 import { Dashboard, VirtualMachinesView } from "./components/index";
-import { StorageOffloadTab } from "./components/StorageOffloadEstimatorModal";
 import { VMUtilizationMetrics } from "./components/VMUtilizationMetrics";
 import {
   filtersToByExpression,
@@ -44,11 +44,6 @@ import {
   searchParamsToFilters,
 } from "./components/vmFilters";
 import { Header } from "./Header";
-
-// Helper type to access SDK configuration (workaround for SDK bug)
-type ApiWithConfig = DefaultApiInterface & {
-  configuration?: { basePath?: string };
-};
 
 export const ReportContainer: React.FC = () => {
   const agentApi = useInjection<DefaultApiInterface>(Symbols.AgentApi);
@@ -66,13 +61,6 @@ export const ReportContainer: React.FC = () => {
   const [shareError, setShareError] = useState<string | null>(null);
   const [utilizationMetrics, setUtilizationMetrics] =
     useState<RightsizingClusterUtilization | null>(null);
-  // Derive base path for forecaster API (same root as agent API)
-  const forecasterBasePath = useMemo(
-    () =>
-      (agentApi as ApiWithConfig).configuration?.basePath ||
-      `${window.location.origin}/api/v1`,
-    [agentApi],
-  );
 
   // Separate request IDs for the initial/effect-driven fetch vs. polling refresh
   // so that concurrent calls from different sources don't discard each other's
@@ -93,11 +81,13 @@ export const ReportContainer: React.FC = () => {
     datacenters: string[];
     concernLabels: string[];
     concernCategories: string[];
+    vmLabels: string[];
   }>({
     clusters: [],
     datacenters: [],
     concernLabels: [],
     concernCategories: [],
+    vmLabels: [],
   });
   const [filterOptionsFetched, setFilterOptionsFetched] = useState(false);
 
@@ -147,9 +137,7 @@ export const ReportContainer: React.FC = () => {
         // Workaround: Fetch directly with native fetch API to bypass SDK bug
         // The published SDK has a bug where GetInventory200ResponseFromJSONTyped returns {}
         // when it receives snake_case JSON from the API
-        const basePath =
-          (agentApi as ApiWithConfig).configuration?.basePath ||
-          `${window.location.origin}/agent/api/v1`;
+        const basePath = getAgentApiBasePath(agentApi);
 
         const httpResponse = await fetch(`${basePath}/inventory`);
 
@@ -260,12 +248,16 @@ export const ReportContainer: React.FC = () => {
 
     const fetchFilterOptions = async () => {
       try {
-        const response = await agentApi.getVMsFilterOptions();
+        const [response, labelsResponse] = await Promise.all([
+          agentApi.getVMsFilterOptions(),
+          agentApi.getVMLabels().catch(() => ({ labels: [] as string[] })),
+        ]);
         setAvailableFilterOptions({
           clusters: response.clusters || [],
           datacenters: response.datacenters || [],
           concernLabels: response.concernLabels || [],
           concernCategories: response.concernCategories || [],
+          vmLabels: labelsResponse.labels || [],
         });
         setFilterOptionsFetched(true);
       } catch (err) {
@@ -459,9 +451,7 @@ export const ReportContainer: React.FC = () => {
   const handleDownloadInventory = async () => {
     try {
       // Workaround: Fetch directly to bypass SDK bug (same as in the main fetch)
-      const basePath =
-        (agentApi as ApiWithConfig).configuration?.basePath ||
-        `${window.location.origin}/agent/api/v1`;
+      const basePath = getAgentApiBasePath(agentApi);
 
       const httpResponse = await fetch(
         `${basePath}/inventory?withAgentId=true`,
@@ -537,6 +527,7 @@ export const ReportContainer: React.FC = () => {
       newParams.delete("memoryRangeMin");
       newParams.delete("memoryRangeMax");
       newParams.delete("migrationReadiness");
+      newParams.delete("vmLabels");
       newParams.delete("concernLabels");
       newParams.delete("concernCategories");
       setSearchParams(newParams, { replace: true });
@@ -569,6 +560,7 @@ export const ReportContainer: React.FC = () => {
       newParams.delete("memoryRangeMin");
       newParams.delete("memoryRangeMax");
       newParams.delete("migrationReadiness");
+      newParams.delete("vmLabels");
       newParams.delete("concernLabels");
       newParams.delete("concernCategories");
     } else {
@@ -585,6 +577,7 @@ export const ReportContainer: React.FC = () => {
       newParams.delete("memoryRangeMin");
       newParams.delete("memoryRangeMax");
       newParams.delete("migrationReadiness");
+      newParams.delete("vmLabels");
       newParams.delete("concernLabels");
       newParams.delete("concernCategories");
     }
@@ -738,12 +731,6 @@ export const ReportContainer: React.FC = () => {
                   }}
                 />
               </div>
-            </Tab>
-            <Tab
-              eventKey={2}
-              title={<TabTitleText>Storage offload estimator</TabTitleText>}
-            >
-              <StorageOffloadTab basePath={forecasterBasePath} />
             </Tab>
           </Tabs>
         </StackItem>

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -325,15 +325,22 @@ export const ReportContainer: React.FC = () => {
     try {
       const effectiveFilters = { ...initialVMFilters, showExcludedVMs };
       const byExpression = filtersToByExpression(effectiveFilters);
-      const response = await agentApi.getVMs({
-        byExpression,
-        sort: vmsSortFields.length > 0 ? vmsSortFields : undefined,
-        page: vmsPage,
-        pageSize: vmsPageSize,
-      });
+      const [response, labelsResponse] = await Promise.all([
+        agentApi.getVMs({
+          byExpression,
+          sort: vmsSortFields.length > 0 ? vmsSortFields : undefined,
+          page: vmsPage,
+          pageSize: vmsPageSize,
+        }),
+        agentApi.getVMLabels().catch(() => ({ labels: [] as string[] })),
+      ]);
       if (vmsRefreshIdRef.current === reqId) {
         setVmsList(response.vms || []);
         setVmsTotalCount(response.total || 0);
+        setAvailableFilterOptions((prev) => ({
+          ...prev,
+          vmLabels: labelsResponse.labels || [],
+        }));
       }
     } catch (err) {
       console.error("Error refreshing VMs:", err);

--- a/apps/agent-ui/src/pages/Report/ReportLayout.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportLayout.tsx
@@ -15,6 +15,7 @@ import {
 } from "@patternfly/react-core";
 import { BarsIcon } from "@patternfly/react-icons";
 import type React from "react";
+import { useEffect } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
 const NAV_ITEMS = [
@@ -33,6 +34,12 @@ export const ReportLayout: React.FC = () => {
   const activeItem = NAV_ITEMS.find((item) =>
     location.pathname.startsWith(item.path),
   );
+
+  useEffect(() => {
+    document.title = activeItem
+      ? `${activeItem.label} | Migration Advisor`
+      : "Migration Advisor";
+  }, [activeItem]);
 
   return (
     <Page

--- a/apps/agent-ui/src/pages/Report/StorageOffloadPage.tsx
+++ b/apps/agent-ui/src/pages/Report/StorageOffloadPage.tsx
@@ -4,21 +4,13 @@ import { PageSection } from "@patternfly/react-core";
 import type React from "react";
 import { useMemo } from "react";
 import { Symbols } from "../../main/Symbols";
+import { getAgentApiBasePath } from "./agentApiConfig";
 import { StorageOffloadTab } from "./components/StorageOffloadEstimatorModal";
-
-type ApiWithConfig = DefaultApiInterface & {
-  configuration?: { basePath?: string };
-};
 
 export const StorageOffloadPage: React.FC = () => {
   const agentApi = useInjection<DefaultApiInterface>(Symbols.AgentApi);
 
-  const basePath = useMemo(
-    () =>
-      (agentApi as ApiWithConfig).configuration?.basePath ||
-      `${window.location.origin}/api/v1`,
-    [agentApi],
-  );
+  const basePath = useMemo(() => getAgentApiBasePath(agentApi), [agentApi]);
 
   return (
     <PageSection hasBodyWrapper={false} isFilled style={{ padding: "24px" }}>

--- a/apps/agent-ui/src/pages/Report/agentApiConfig.ts
+++ b/apps/agent-ui/src/pages/Report/agentApiConfig.ts
@@ -1,0 +1,13 @@
+import type { DefaultApiInterface } from "@openshift-migration-advisor/agent-sdk";
+
+/** Workaround: access SDK configuration.basePath (not exposed on DefaultApiInterface). */
+export type ApiWithConfig = DefaultApiInterface & {
+  configuration?: { basePath?: string };
+};
+
+export function getAgentApiBasePath(agentApi?: DefaultApiInterface): string {
+  return (
+    (agentApi as ApiWithConfig | undefined)?.configuration?.basePath ||
+    `${window.location.origin}/agent/api/v1`
+  );
+}

--- a/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
@@ -68,19 +68,23 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
     setLabels(labels.filter((l) => l.id !== labelId));
   };
 
-  const onEdit = (nextText: string, index: number) => {
-    const copy = [...labels];
-    copy[index] = {
-      ...labels[index],
-      name: nextText,
-      props: {
-        ...labels[index].props,
-        editableProps: {
-          "aria-label": `Editable label with text ${nextText}`,
-        },
-      },
-    };
-    setLabels(copy);
+  const onEdit = (nextText: string, labelId: number) => {
+    setLabels((prev) =>
+      prev.map((l) =>
+        l.id === labelId
+          ? {
+              ...l,
+              name: nextText,
+              props: {
+                ...l.props,
+                editableProps: {
+                  "aria-label": `Editable label with text ${nextText}`,
+                },
+              },
+            }
+          : l,
+      ),
+    );
   };
 
   const handleSubmit = async () => {
@@ -130,12 +134,12 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
             </Label>
           }
         >
-          {labels.map((label, index) => (
+          {labels.map((label) => (
             <Label
               key={label.id}
               onClose={() => onLabelClose(label.id)}
-              onEditCancel={(_event, prevText) => onEdit(prevText, index)}
-              onEditComplete={(_event, newText) => onEdit(newText, index)}
+              onEditCancel={(_event, prevText) => onEdit(prevText, label.id)}
+              onEditComplete={(_event, newText) => onEdit(newText, label.id)}
               {...label.props}
             >
               {label.name}

--- a/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
@@ -31,6 +31,7 @@ interface AddLabelsModalProps {
   selectedVMCount: number;
   existingLabels: string[];
   currentVMLabels?: string[];
+  selectedVMName?: string;
 }
 
 export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
@@ -40,11 +41,11 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
   selectedVMCount,
   existingLabels,
   currentVMLabels = [],
+  selectedVMName,
 }) => {
   const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [selected, setSelected] = useState<string[]>([]);
-  const [removedLabels, setRemovedLabels] = useState<string[]>([]);
   const [selectOptions, setSelectOptions] = useState<SelectOptionProps[]>([]);
   const [focusedItemIndex, setFocusedItemIndex] = useState<number | null>(null);
   const [activeItemId, setActiveItemId] = useState<string | null>(null);
@@ -53,15 +54,14 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
 
   useEffect(() => {
     if (isOpen) {
-      setSelected([]);
-      setRemovedLabels([]);
+      setSelected([...currentVMLabels]);
       setInputValue("");
       setIsSelectOpen(false);
       setIsSubmitting(false);
       setFocusedItemIndex(null);
       setActiveItemId(null);
     }
-  }, [isOpen]);
+  }, [isOpen, currentVMLabels]);
 
   useEffect(() => {
     let newOptions: SelectOptionProps[];
@@ -159,7 +159,6 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       const trimmed = inputValue.trim();
       if (trimmed && !selected.includes(trimmed)) {
         setSelected((prev) => [...prev, trimmed]);
-        setRemovedLabels((prev) => prev.filter((l) => l !== trimmed));
       }
       setInputValue("");
       resetActiveAndFocusedItem();
@@ -171,7 +170,6 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       setSelected((prev) => prev.filter((s) => s !== value));
     } else {
       setSelected((prev) => [...prev, value]);
-      setRemovedLabels((prev) => prev.filter((l) => l !== value));
     }
     textInputRef.current?.focus();
   };
@@ -268,18 +266,15 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
     textInputRef.current?.focus();
   };
 
-  const removeCurrentLabel = (label: string) => {
-    setRemovedLabels((prev) => [...prev, label]);
-    setSelected((prev) => prev.filter((s) => s !== label));
-  };
-
-  const hasChanges = selected.length > 0 || removedLabels.length > 0;
+  const labelsToAdd = selected.filter((l) => !currentVMLabels.includes(l));
+  const labelsToRemove = currentVMLabels.filter((l) => !selected.includes(l));
+  const hasChanges = labelsToAdd.length > 0 || labelsToRemove.length > 0;
 
   const handleSubmit = async () => {
     if (!hasChanges) return;
     setIsSubmitting(true);
     try {
-      await onSubmit(selected, removedLabels);
+      await onSubmit(labelsToAdd, labelsToRemove);
       onClose();
     } catch (err) {
       console.error("Error updating labels:", err);
@@ -306,13 +301,13 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
           id="add-labels-typeahead-input"
           autoComplete="off"
           innerRef={textInputRef}
-          placeholder="Select or create labels"
+          placeholder="Type or select labels..."
           {...(activeItemId && { "aria-activedescendant": activeItemId })}
           role="combobox"
           isExpanded={isSelectOpen}
           aria-controls="add-labels-typeahead-listbox"
         >
-          <LabelGroup aria-label="Current selections">
+          <LabelGroup aria-label="Current selections" numLabels={5}>
             {selected.map((selection) => (
               <Label
                 key={selection}
@@ -349,41 +344,23 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       aria-describedby="add-labels-body"
       variant="medium"
     >
-      <ModalHeader title="Edit labels" labelId="add-labels-title" />
+      <ModalHeader
+        title={selectedVMName ? "Edit labels" : "Add labels"}
+        labelId="add-labels-title"
+      />
       <ModalBody id="add-labels-body" style={{ minHeight: "220px" }}>
         <Content component="p" style={{ marginBottom: "16px" }}>
-          Applies to the {selectedVMCount} selected VM
-          {selectedVMCount !== 1 ? "s" : ""}. You can add new labels, select
-          existing ones, or remove current labels.
+          {selectedVMName ? (
+            <>
+              Add or remove labels for <strong>{selectedVMName}</strong>.
+            </>
+          ) : (
+            `Applies to the ${selectedVMCount} selected VM${selectedVMCount !== 1 ? "s" : ""}. You can add a custom label, or select an existing label.`
+          )}
         </Content>
 
-        {currentVMLabels.length > 0 && (
-          <>
-            <div style={{ marginBottom: "8px" }}>
-              <strong>Current labels</strong>
-            </div>
-            <LabelGroup
-              aria-label="Current VM labels"
-              numLabels={20}
-              style={{ marginBottom: "16px" }}
-            >
-              {currentVMLabels
-                .filter((label) => !removedLabels.includes(label))
-                .map((label) => (
-                  <Label
-                    key={label}
-                    color="blue"
-                    onClose={() => removeCurrentLabel(label)}
-                  >
-                    {label}
-                  </Label>
-                ))}
-            </LabelGroup>
-          </>
-        )}
-
         <div style={{ marginBottom: "8px" }}>
-          <strong>Add labels</strong>
+          <strong>Labels</strong>
         </div>
 
         <Select

--- a/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
@@ -1,0 +1,366 @@
+import { css } from "@emotion/css";
+import {
+  Button,
+  Content,
+  Label,
+  LabelGroup,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TextInput,
+} from "@patternfly/react-core";
+import type React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const styles = {
+  inputWrapper: css`
+    position: relative;
+  `,
+  labelsInput: css`
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 8px;
+    border: 1px solid var(--pf-t--global--border--color--default);
+    border-radius: var(--pf-t--global--border--radius--small);
+    min-height: 36px;
+    cursor: text;
+    &:focus-within {
+      border-color: var(--pf-t--global--border--color--hover);
+      outline: 2px solid var(--pf-t--global--color--brand--default);
+      outline-offset: 1px;
+    }
+  `,
+  textInput: css`
+    border: none !important;
+    outline: none !important;
+    box-shadow: none !important;
+    flex: 1;
+    min-width: 120px;
+    padding: 0 !important;
+    background: transparent !important;
+    &:focus {
+      border: none !important;
+      outline: none !important;
+      box-shadow: none !important;
+    }
+  `,
+  dropdown: css`
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background: var(--pf-t--global--background--color--primary--default);
+    border: 1px solid var(--pf-t--global--border--color--default);
+    border-radius: var(--pf-t--global--border--radius--small);
+    box-shadow: var(--pf-t--global--box-shadow--md);
+    margin-top: 4px;
+    max-height: 200px;
+    overflow-y: auto;
+  `,
+  dropdownItem: css`
+    display: block;
+    width: 100%;
+    padding: 8px 12px;
+    cursor: pointer;
+    background: none;
+    border: none;
+    text-align: left;
+    font: inherit;
+    &:hover {
+      background: var(--pf-t--global--background--color--primary--hover);
+    }
+  `,
+  dropdownItemHighlighted: css`
+    display: block;
+    width: 100%;
+    padding: 8px 12px;
+    cursor: pointer;
+    background: var(--pf-t--global--background--color--primary--hover);
+    border: none;
+    text-align: left;
+    font: inherit;
+  `,
+  dropdownSection: css`
+    padding: 4px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--pf-t--global--text--color--subtle);
+  `,
+};
+
+function labelsMatch(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+function findExistingLabel(
+  value: string,
+  existingLabels: string[],
+): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return existingLabels.find((label) => labelsMatch(label, trimmed));
+}
+
+interface AddLabelsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (labels: string[]) => Promise<void>;
+  selectedVMCount: number;
+  existingLabels: string[];
+}
+
+export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  selectedVMCount,
+  existingLabels,
+}) => {
+  const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
+  const [inputValue, setInputValue] = useState("");
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedLabels([]);
+      setInputValue("");
+      setIsDropdownOpen(false);
+      setIsSubmitting(false);
+      setHighlightedIndex(-1);
+    }
+  }, [isOpen]);
+
+  const unselectedExistingLabels = useMemo(
+    () =>
+      existingLabels.filter(
+        (label) =>
+          !selectedLabels.some((selected) => labelsMatch(selected, label)),
+      ),
+    [existingLabels, selectedLabels],
+  );
+
+  const matchingExistingLabels = useMemo(() => {
+    const query = inputValue.trim().toLowerCase();
+    if (!query) return unselectedExistingLabels;
+    return unselectedExistingLabels.filter((label) =>
+      label.toLowerCase().includes(query),
+    );
+  }, [inputValue, unselectedExistingLabels]);
+
+  const showCreateOption = useMemo(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return false;
+    const alreadyExists = findExistingLabel(trimmed, existingLabels);
+    const alreadySelected = selectedLabels.some((l) => labelsMatch(l, trimmed));
+    return !alreadyExists && !alreadySelected;
+  }, [inputValue, existingLabels, selectedLabels]);
+
+  const dropdownItems = useMemo(() => {
+    const items: { type: "create" | "existing"; value: string }[] = [];
+    for (const label of matchingExistingLabels) {
+      items.push({ type: "existing", value: label });
+    }
+    if (showCreateOption) {
+      items.push({ type: "create", value: inputValue.trim() });
+    }
+    return items;
+  }, [matchingExistingLabels, showCreateOption, inputValue]);
+
+  const addLabel = useCallback(
+    (label: string) => {
+      const trimmed = label.trim();
+      if (!trimmed) return;
+
+      const canonical = findExistingLabel(trimmed, existingLabels) ?? trimmed;
+      if (selectedLabels.some((l) => labelsMatch(l, canonical))) {
+        setInputValue("");
+        setHighlightedIndex(-1);
+        inputRef.current?.focus();
+        return;
+      }
+
+      setSelectedLabels((prev) => [...prev, canonical]);
+      setInputValue("");
+      setIsDropdownOpen(false);
+      setHighlightedIndex(-1);
+      inputRef.current?.focus();
+    },
+    [selectedLabels, existingLabels],
+  );
+
+  const removeLabel = useCallback((label: string) => {
+    setSelectedLabels((prev) => prev.filter((l) => l !== label));
+  }, []);
+
+  const handleInputChange = (
+    _event: React.FormEvent<HTMLInputElement>,
+    value: string,
+  ) => {
+    setInputValue(value);
+    setIsDropdownOpen(true);
+    setHighlightedIndex(-1);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (highlightedIndex >= 0 && highlightedIndex < dropdownItems.length) {
+        addLabel(dropdownItems[highlightedIndex].value);
+      } else if (inputValue.trim()) {
+        const existing = findExistingLabel(inputValue, existingLabels);
+        addLabel(existing ?? inputValue.trim());
+      }
+    } else if (
+      event.key === "Backspace" &&
+      !inputValue &&
+      selectedLabels.length > 0
+    ) {
+      removeLabel(selectedLabels[selectedLabels.length - 1]);
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (!isDropdownOpen) setIsDropdownOpen(true);
+      setHighlightedIndex((prev) =>
+        prev < dropdownItems.length - 1 ? prev + 1 : prev,
+      );
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : -1));
+    } else if (event.key === "Escape") {
+      setIsDropdownOpen(false);
+      setHighlightedIndex(-1);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (selectedLabels.length === 0) return;
+    setIsSubmitting(true);
+    try {
+      await onSubmit(selectedLabels);
+      onClose();
+    } catch (err) {
+      console.error("Error adding labels:", err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      aria-labelledby="add-labels-title"
+      aria-describedby="add-labels-body"
+      variant="medium"
+    >
+      <ModalHeader title="Add labels" labelId="add-labels-title" />
+      <ModalBody
+        id="add-labels-body"
+        style={{ minHeight: "180px", overflow: "visible" }}
+      >
+        <Content component="p" style={{ marginBottom: "16px" }}>
+          Applies to the {selectedVMCount} selected VM
+          {selectedVMCount !== 1 ? "s" : ""}. You can add a custom label, or
+          select an existing label.
+        </Content>
+
+        <div style={{ marginBottom: "8px" }}>
+          <strong>Labels</strong>
+        </div>
+
+        <div className={styles.inputWrapper}>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: focus delegation to inner input */}
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled by inner input */}
+          <div
+            className={styles.labelsInput}
+            onClick={() => inputRef.current?.focus()}
+          >
+            {selectedLabels.length > 0 && (
+              <LabelGroup>
+                {selectedLabels.map((label) => (
+                  <Label key={label} onClose={() => removeLabel(label)}>
+                    {label}
+                  </Label>
+                ))}
+              </LabelGroup>
+            )}
+            <TextInput
+              ref={inputRef}
+              type="text"
+              value={inputValue}
+              onChange={handleInputChange}
+              onKeyDown={handleKeyDown}
+              onFocus={() => setIsDropdownOpen(true)}
+              aria-expanded={isDropdownOpen && dropdownItems.length > 0}
+              aria-autocomplete="list"
+              aria-controls="add-labels-suggestions"
+              onBlur={() => {
+                setTimeout(() => setIsDropdownOpen(false), 200);
+              }}
+              className={styles.textInput}
+              aria-label="Type to add labels"
+              placeholder="Search existing or type a new label..."
+            />
+          </div>
+
+          {isDropdownOpen && dropdownItems.length > 0 && (
+            <div
+              id="add-labels-suggestions"
+              className={styles.dropdown}
+              role="listbox"
+            >
+              {matchingExistingLabels.length > 0 && (
+                <div className={styles.dropdownSection}>Existing labels</div>
+              )}
+              {dropdownItems.map((item, index) => (
+                <button
+                  type="button"
+                  key={`${item.type}-${item.value}`}
+                  role="option"
+                  aria-selected={index === highlightedIndex}
+                  className={
+                    index === highlightedIndex
+                      ? styles.dropdownItemHighlighted
+                      : styles.dropdownItem
+                  }
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    addLabel(item.value);
+                  }}
+                  onMouseEnter={() => setHighlightedIndex(index)}
+                >
+                  {item.type === "create" ? (
+                    <>Create label &quot;{item.value}&quot;</>
+                  ) : (
+                    item.value
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="primary"
+          onClick={handleSubmit}
+          isDisabled={selectedLabels.length === 0 || isSubmitting}
+          isLoading={isSubmitting}
+        >
+          Add labels
+        </Button>
+        <Button variant="link" onClick={onClose} isDisabled={isSubmitting}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+AddLabelsModal.displayName = "AddLabelsModal";

--- a/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
@@ -161,6 +161,7 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       const trimmed = inputValue.trim();
       if (trimmed && !selected.includes(trimmed)) {
         setSelected((prev) => [...prev, trimmed]);
+        setRemovedLabels((prev) => prev.filter((l) => l !== trimmed));
       }
       setInputValue("");
       resetActiveAndFocusedItem();
@@ -168,9 +169,12 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       return;
     }
 
-    setSelected((prev) =>
-      prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value],
-    );
+    if (selected.includes(value)) {
+      setSelected((prev) => prev.filter((s) => s !== value));
+    } else {
+      setSelected((prev) => [...prev, value]);
+      setRemovedLabels((prev) => prev.filter((l) => l !== value));
+    }
     textInputRef.current?.focus();
   };
 
@@ -268,6 +272,7 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
 
   const removeCurrentLabel = (label: string) => {
     setRemovedLabels((prev) => [...prev, label]);
+    setSelected((prev) => prev.filter((s) => s !== label));
   };
 
   const hasChanges = selected.length > 0 || removedLabels.length > 0;

--- a/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
@@ -3,29 +3,34 @@ import {
   Content,
   Label,
   LabelGroup,
+  MenuToggle,
+  type MenuToggleElement,
   Modal,
   ModalBody,
   ModalFooter,
   ModalHeader,
+  Select,
+  SelectList,
+  SelectOption,
+  type SelectOptionProps,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
 } from "@patternfly/react-core";
+import { TimesIcon } from "@patternfly/react-icons";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-interface LabelItem {
-  name: string;
-  id: number;
-  props: {
-    isEditable: boolean;
-    editableProps: { "aria-label": string };
-  };
-}
+const NO_RESULTS = "no-results";
+const CREATE_NEW = "create-new";
 
 interface AddLabelsModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (labels: string[]) => Promise<void>;
+  onSubmit: (labelsToAdd: string[], labelsToRemove: string[]) => Promise<void>;
   selectedVMCount: number;
   existingLabels: string[];
+  currentVMLabels?: string[];
 }
 
 export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
@@ -33,77 +38,305 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
   onClose,
   onSubmit,
   selectedVMCount,
-  existingLabels: _existingLabels,
+  existingLabels,
+  currentVMLabels = [],
 }) => {
-  const [labels, setLabels] = useState<LabelItem[]>([]);
-  const [idIndex, setIdIndex] = useState(0);
+  const [isSelectOpen, setIsSelectOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [selected, setSelected] = useState<string[]>([]);
+  const [removedLabels, setRemovedLabels] = useState<string[]>([]);
+  const [selectOptions, setSelectOptions] = useState<SelectOptionProps[]>([]);
+  const [focusedItemIndex, setFocusedItemIndex] = useState<number | null>(null);
+  const [activeItemId, setActiveItemId] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const textInputRef = useRef<HTMLInputElement>(undefined);
 
   useEffect(() => {
     if (isOpen) {
-      setLabels([]);
-      setIdIndex(0);
+      setSelected([]);
+      setRemovedLabels([]);
+      setInputValue("");
+      setIsSelectOpen(false);
       setIsSubmitting(false);
+      setFocusedItemIndex(null);
+      setActiveItemId(null);
     }
   }, [isOpen]);
 
-  const onAdd = () => {
-    setLabels([
-      {
-        name: "New label",
-        id: idIndex,
-        props: {
-          isEditable: true,
-          editableProps: {
-            "aria-label": "Editable label with text New label",
-          },
-        },
-      },
-      ...labels,
-    ]);
-    setIdIndex(idIndex + 1);
+  useEffect(() => {
+    let newOptions: SelectOptionProps[];
+
+    if (inputValue) {
+      const filtered = existingLabels.filter((label) =>
+        label.toLowerCase().includes(inputValue.toLowerCase()),
+      );
+
+      if (filtered.length === 0) {
+        const alreadySelected = selected.some(
+          (s) => s.toLowerCase() === inputValue.trim().toLowerCase(),
+        );
+
+        if (!alreadySelected && inputValue.trim()) {
+          newOptions = [
+            {
+              value: CREATE_NEW,
+              children: `Create "${inputValue.trim()}"`,
+            },
+          ];
+        } else {
+          newOptions = [
+            {
+              isAriaDisabled: true,
+              children: `No results found for "${inputValue}"`,
+              value: NO_RESULTS,
+            },
+          ];
+        }
+      } else {
+        newOptions = filtered.map((label) => ({
+          value: label,
+          children: label,
+          hasCheckbox: true,
+          isSelected: selected.includes(label),
+        }));
+
+        const exactMatch = existingLabels.some(
+          (l) => l.toLowerCase() === inputValue.trim().toLowerCase(),
+        );
+        const alreadySelected = selected.some(
+          (s) => s.toLowerCase() === inputValue.trim().toLowerCase(),
+        );
+        if (!exactMatch && !alreadySelected && inputValue.trim()) {
+          newOptions.push({
+            value: CREATE_NEW,
+            children: `Create "${inputValue.trim()}"`,
+          });
+        }
+      }
+    } else {
+      newOptions = existingLabels.map((label) => ({
+        value: label,
+        children: label,
+        hasCheckbox: true,
+        isSelected: selected.includes(label),
+      }));
+    }
+
+    setSelectOptions(newOptions);
+  }, [inputValue, existingLabels, selected]);
+
+  const createItemId = (value: string) =>
+    `select-multi-typeahead-${value.replace(/\s/g, "-")}`;
+
+  const setActiveAndFocusedItem = (itemIndex: number) => {
+    setFocusedItemIndex(itemIndex);
+    const focusedItem = selectOptions[itemIndex];
+    if (focusedItem) {
+      setActiveItemId(createItemId(String(focusedItem.value)));
+    }
   };
 
-  const onLabelClose = (labelId: number) => {
-    setLabels(labels.filter((l) => l.id !== labelId));
+  const resetActiveAndFocusedItem = () => {
+    setFocusedItemIndex(null);
+    setActiveItemId(null);
   };
 
-  const onEdit = (nextText: string, labelId: number) => {
-    setLabels((prev) =>
-      prev.map((l) =>
-        l.id === labelId
-          ? {
-              ...l,
-              name: nextText,
-              props: {
-                ...l.props,
-                editableProps: {
-                  "aria-label": `Editable label with text ${nextText}`,
-                },
-              },
-            }
-          : l,
-      ),
+  const closeMenu = () => {
+    setIsSelectOpen(false);
+    resetActiveAndFocusedItem();
+  };
+
+  const onInputClick = () => {
+    if (!isSelectOpen) {
+      setIsSelectOpen(true);
+    } else if (!inputValue) {
+      closeMenu();
+    }
+  };
+
+  const onSelect = (value: string) => {
+    if (value === NO_RESULTS) return;
+
+    if (value === CREATE_NEW) {
+      const trimmed = inputValue.trim();
+      if (trimmed && !selected.includes(trimmed)) {
+        setSelected((prev) => [...prev, trimmed]);
+      }
+      setInputValue("");
+      resetActiveAndFocusedItem();
+      textInputRef.current?.focus();
+      return;
+    }
+
+    setSelected((prev) =>
+      prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value],
     );
+    textInputRef.current?.focus();
   };
+
+  const onTextInputChange = (
+    _event: React.FormEvent<HTMLInputElement>,
+    value: string,
+  ) => {
+    setInputValue(value);
+    resetActiveAndFocusedItem();
+    if (!isSelectOpen) {
+      setIsSelectOpen(true);
+    }
+  };
+
+  const handleMenuArrowKeys = (key: string) => {
+    if (!isSelectOpen) {
+      setIsSelectOpen(true);
+    }
+
+    if (selectOptions.every((option) => option.isAriaDisabled)) {
+      return;
+    }
+
+    let indexToFocus = 0;
+
+    if (key === "ArrowUp") {
+      if (focusedItemIndex === null || focusedItemIndex === 0) {
+        indexToFocus = selectOptions.length - 1;
+      } else {
+        indexToFocus = focusedItemIndex - 1;
+      }
+      while (selectOptions[indexToFocus]?.isAriaDisabled) {
+        indexToFocus--;
+        if (indexToFocus < 0) indexToFocus = selectOptions.length - 1;
+      }
+    }
+
+    if (key === "ArrowDown") {
+      if (
+        focusedItemIndex === null ||
+        focusedItemIndex === selectOptions.length - 1
+      ) {
+        indexToFocus = 0;
+      } else {
+        indexToFocus = focusedItemIndex + 1;
+      }
+      while (selectOptions[indexToFocus]?.isAriaDisabled) {
+        indexToFocus++;
+        if (indexToFocus >= selectOptions.length) indexToFocus = 0;
+      }
+    }
+
+    setActiveAndFocusedItem(indexToFocus);
+  };
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const focusedItem =
+      focusedItemIndex !== null ? selectOptions[focusedItemIndex] : null;
+
+    switch (event.key) {
+      case "Enter":
+        event.preventDefault();
+        if (
+          isSelectOpen &&
+          focusedItem &&
+          !focusedItem.isAriaDisabled &&
+          focusedItem.value !== NO_RESULTS
+        ) {
+          onSelect(String(focusedItem.value));
+        } else if (!isSelectOpen) {
+          setIsSelectOpen(true);
+        } else if (inputValue.trim()) {
+          onSelect(CREATE_NEW);
+        }
+        break;
+      case "ArrowUp":
+      case "ArrowDown":
+        event.preventDefault();
+        handleMenuArrowKeys(event.key);
+        break;
+    }
+  };
+
+  const onToggleClick = () => {
+    setIsSelectOpen(!isSelectOpen);
+    textInputRef.current?.focus();
+  };
+
+  const onClearButtonClick = () => {
+    setSelected([]);
+    setInputValue("");
+    resetActiveAndFocusedItem();
+    textInputRef.current?.focus();
+  };
+
+  const removeCurrentLabel = (label: string) => {
+    setRemovedLabels((prev) => [...prev, label]);
+  };
+
+  const hasChanges = selected.length > 0 || removedLabels.length > 0;
 
   const handleSubmit = async () => {
-    const labelNames = labels
-      .map((l) => l.name.trim())
-      .filter((name) => name.length > 0);
-    if (labelNames.length === 0) return;
-
-    const uniqueNames = [...new Set(labelNames)];
+    if (!hasChanges) return;
     setIsSubmitting(true);
     try {
-      await onSubmit(uniqueNames);
+      await onSubmit(selected, removedLabels);
       onClose();
     } catch (err) {
-      console.error("Error adding labels:", err);
+      console.error("Error updating labels:", err);
     } finally {
       setIsSubmitting(false);
     }
   };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      variant="typeahead"
+      aria-label="Multi typeahead labels toggle"
+      onClick={onToggleClick}
+      innerRef={toggleRef}
+      isExpanded={isSelectOpen}
+      isFullWidth
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={inputValue}
+          onClick={onInputClick}
+          onChange={onTextInputChange}
+          onKeyDown={onInputKeyDown}
+          id="add-labels-typeahead-input"
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder="Select or create labels"
+          {...(activeItemId && { "aria-activedescendant": activeItemId })}
+          role="combobox"
+          isExpanded={isSelectOpen}
+          aria-controls="add-labels-typeahead-listbox"
+        >
+          <LabelGroup aria-label="Current selections">
+            {selected.map((selection) => (
+              <Label
+                key={selection}
+                variant="outline"
+                onClose={(ev) => {
+                  ev.stopPropagation();
+                  onSelect(selection);
+                }}
+              >
+                {selection}
+              </Label>
+            ))}
+          </LabelGroup>
+        </TextInputGroupMain>
+        <TextInputGroupUtilities
+          {...(selected.length === 0 ? { style: { display: "none" } } : {})}
+        >
+          <Button
+            variant="plain"
+            onClick={onClearButtonClick}
+            aria-label="Clear input value"
+            icon={<TimesIcon />}
+          />
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  );
 
   return (
     <Modal
@@ -113,48 +346,76 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       aria-describedby="add-labels-body"
       variant="medium"
     >
-      <ModalHeader title="Add labels" labelId="add-labels-title" />
-      <ModalBody id="add-labels-body" style={{ minHeight: "180px" }}>
+      <ModalHeader title="Edit labels" labelId="add-labels-title" />
+      <ModalBody id="add-labels-body" style={{ minHeight: "220px" }}>
         <Content component="p" style={{ marginBottom: "16px" }}>
           Applies to the {selectedVMCount} selected VM
-          {selectedVMCount !== 1 ? "s" : ""}. You can add a custom label, or
-          select an existing label.
+          {selectedVMCount !== 1 ? "s" : ""}. You can add new labels, select
+          existing ones, or remove current labels.
         </Content>
 
+        {currentVMLabels.length > 0 && (
+          <>
+            <div style={{ marginBottom: "8px" }}>
+              <strong>Current labels</strong>
+            </div>
+            <LabelGroup
+              aria-label="Current VM labels"
+              numLabels={20}
+              style={{ marginBottom: "16px" }}
+            >
+              {currentVMLabels
+                .filter((label) => !removedLabels.includes(label))
+                .map((label) => (
+                  <Label
+                    key={label}
+                    color="blue"
+                    onClose={() => removeCurrentLabel(label)}
+                  >
+                    {label}
+                  </Label>
+                ))}
+            </LabelGroup>
+          </>
+        )}
+
         <div style={{ marginBottom: "8px" }}>
-          <strong>Labels</strong>
+          <strong>Add labels</strong>
         </div>
 
-        <LabelGroup
-          aria-label="Labels to add"
-          numLabels={20}
-          addLabelControl={
-            <Label variant="add" onClick={onAdd}>
-              Add label
-            </Label>
-          }
+        <Select
+          id="add-labels-typeahead-select"
+          isOpen={isSelectOpen}
+          selected={selected}
+          onSelect={(_event, selection) => onSelect(selection as string)}
+          onOpenChange={(open) => {
+            if (!open) closeMenu();
+          }}
+          toggle={toggle}
+          variant="typeahead"
         >
-          {labels.map((label) => (
-            <Label
-              key={label.id}
-              onClose={() => onLabelClose(label.id)}
-              onEditCancel={(_event, prevText) => onEdit(prevText, label.id)}
-              onEditComplete={(_event, newText) => onEdit(newText, label.id)}
-              {...label.props}
-            >
-              {label.name}
-            </Label>
-          ))}
-        </LabelGroup>
+          <SelectList isAriaMultiselectable id="add-labels-typeahead-listbox">
+            {selectOptions.map((option, index) => (
+              <SelectOption
+                key={option.value || option.children}
+                isFocused={focusedItemIndex === index}
+                className={option.className}
+                id={createItemId(String(option.value))}
+                {...option}
+                ref={null}
+              />
+            ))}
+          </SelectList>
+        </Select>
       </ModalBody>
       <ModalFooter>
         <Button
           variant="primary"
           onClick={handleSubmit}
-          isDisabled={labels.length === 0 || isSubmitting}
+          isDisabled={!hasChanges || isSubmitting}
           isLoading={isSubmitting}
         >
-          Add labels
+          Save
         </Button>
         <Button variant="link" onClick={onClose} isDisabled={isSubmitting}>
           Cancel

--- a/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
@@ -96,7 +96,6 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
         newOptions = filtered.map((label) => ({
           value: label,
           children: label,
-          hasCheckbox: true,
           isSelected: selected.includes(label),
         }));
 
@@ -117,7 +116,6 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       newOptions = existingLabels.map((label) => ({
         value: label,
         children: label,
-        hasCheckbox: true,
         isSelected: selected.includes(label),
       }));
     }

--- a/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
@@ -1,4 +1,3 @@
-import { css } from "@emotion/css";
 import {
   Button,
   Content,
@@ -8,101 +7,17 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
-  TextInput,
 } from "@patternfly/react-core";
 import type React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
-const styles = {
-  inputWrapper: css`
-    position: relative;
-  `,
-  labelsInput: css`
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 4px;
-    padding: 6px 8px;
-    border: 1px solid var(--pf-t--global--border--color--default);
-    border-radius: var(--pf-t--global--border--radius--small);
-    min-height: 36px;
-    cursor: text;
-    &:focus-within {
-      border-color: var(--pf-t--global--border--color--hover);
-      outline: 2px solid var(--pf-t--global--color--brand--default);
-      outline-offset: 1px;
-    }
-  `,
-  textInput: css`
-    border: none !important;
-    outline: none !important;
-    box-shadow: none !important;
-    flex: 1;
-    min-width: 120px;
-    padding: 0 !important;
-    background: transparent !important;
-    &:focus {
-      border: none !important;
-      outline: none !important;
-      box-shadow: none !important;
-    }
-  `,
-  dropdown: css`
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-    background: var(--pf-t--global--background--color--primary--default);
-    border: 1px solid var(--pf-t--global--border--color--default);
-    border-radius: var(--pf-t--global--border--radius--small);
-    box-shadow: var(--pf-t--global--box-shadow--md);
-    margin-top: 4px;
-    max-height: 200px;
-    overflow-y: auto;
-  `,
-  dropdownItem: css`
-    display: block;
-    width: 100%;
-    padding: 8px 12px;
-    cursor: pointer;
-    background: none;
-    border: none;
-    text-align: left;
-    font: inherit;
-    &:hover {
-      background: var(--pf-t--global--background--color--primary--hover);
-    }
-  `,
-  dropdownItemHighlighted: css`
-    display: block;
-    width: 100%;
-    padding: 8px 12px;
-    cursor: pointer;
-    background: var(--pf-t--global--background--color--primary--hover);
-    border: none;
-    text-align: left;
-    font: inherit;
-  `,
-  dropdownSection: css`
-    padding: 4px 12px;
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--pf-t--global--text--color--subtle);
-  `,
-};
-
-function labelsMatch(a: string, b: string): boolean {
-  return a.toLowerCase() === b.toLowerCase();
-}
-
-function findExistingLabel(
-  value: string,
-  existingLabels: string[],
-): string | undefined {
-  const trimmed = value.trim();
-  if (!trimmed) return undefined;
-  return existingLabels.find((label) => labelsMatch(label, trimmed));
+interface LabelItem {
+  name: string;
+  id: number;
+  props: {
+    isEditable: boolean;
+    editableProps: { "aria-label": string };
+  };
 }
 
 interface AddLabelsModalProps {
@@ -118,131 +33,66 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
   onClose,
   onSubmit,
   selectedVMCount,
-  existingLabels,
+  existingLabels: _existingLabels,
 }) => {
-  const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
-  const [inputValue, setInputValue] = useState("");
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [labels, setLabels] = useState<LabelItem[]>([]);
+  const [idIndex, setIdIndex] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [highlightedIndex, setHighlightedIndex] = useState(-1);
-  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (isOpen) {
-      setSelectedLabels([]);
-      setInputValue("");
-      setIsDropdownOpen(false);
+      setLabels([]);
+      setIdIndex(0);
       setIsSubmitting(false);
-      setHighlightedIndex(-1);
     }
   }, [isOpen]);
 
-  const unselectedExistingLabels = useMemo(
-    () =>
-      existingLabels.filter(
-        (label) =>
-          !selectedLabels.some((selected) => labelsMatch(selected, label)),
-      ),
-    [existingLabels, selectedLabels],
-  );
-
-  const matchingExistingLabels = useMemo(() => {
-    const query = inputValue.trim().toLowerCase();
-    if (!query) return unselectedExistingLabels;
-    return unselectedExistingLabels.filter((label) =>
-      label.toLowerCase().includes(query),
-    );
-  }, [inputValue, unselectedExistingLabels]);
-
-  const showCreateOption = useMemo(() => {
-    const trimmed = inputValue.trim();
-    if (!trimmed) return false;
-    const alreadyExists = findExistingLabel(trimmed, existingLabels);
-    const alreadySelected = selectedLabels.some((l) => labelsMatch(l, trimmed));
-    return !alreadyExists && !alreadySelected;
-  }, [inputValue, existingLabels, selectedLabels]);
-
-  const dropdownItems = useMemo(() => {
-    const items: { type: "create" | "existing"; value: string }[] = [];
-    for (const label of matchingExistingLabels) {
-      items.push({ type: "existing", value: label });
-    }
-    if (showCreateOption) {
-      items.push({ type: "create", value: inputValue.trim() });
-    }
-    return items;
-  }, [matchingExistingLabels, showCreateOption, inputValue]);
-
-  const addLabel = useCallback(
-    (label: string) => {
-      const trimmed = label.trim();
-      if (!trimmed) return;
-
-      const canonical = findExistingLabel(trimmed, existingLabels) ?? trimmed;
-      if (selectedLabels.some((l) => labelsMatch(l, canonical))) {
-        setInputValue("");
-        setHighlightedIndex(-1);
-        inputRef.current?.focus();
-        return;
-      }
-
-      setSelectedLabels((prev) => [...prev, canonical]);
-      setInputValue("");
-      setIsDropdownOpen(false);
-      setHighlightedIndex(-1);
-      inputRef.current?.focus();
-    },
-    [selectedLabels, existingLabels],
-  );
-
-  const removeLabel = useCallback((label: string) => {
-    setSelectedLabels((prev) => prev.filter((l) => l !== label));
-  }, []);
-
-  const handleInputChange = (
-    _event: React.FormEvent<HTMLInputElement>,
-    value: string,
-  ) => {
-    setInputValue(value);
-    setIsDropdownOpen(true);
-    setHighlightedIndex(-1);
+  const onAdd = () => {
+    setLabels([
+      {
+        name: "New label",
+        id: idIndex,
+        props: {
+          isEditable: true,
+          editableProps: {
+            "aria-label": "Editable label with text New label",
+          },
+        },
+      },
+      ...labels,
+    ]);
+    setIdIndex(idIndex + 1);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Enter") {
-      event.preventDefault();
-      if (highlightedIndex >= 0 && highlightedIndex < dropdownItems.length) {
-        addLabel(dropdownItems[highlightedIndex].value);
-      } else if (inputValue.trim()) {
-        const existing = findExistingLabel(inputValue, existingLabels);
-        addLabel(existing ?? inputValue.trim());
-      }
-    } else if (
-      event.key === "Backspace" &&
-      !inputValue &&
-      selectedLabels.length > 0
-    ) {
-      removeLabel(selectedLabels[selectedLabels.length - 1]);
-    } else if (event.key === "ArrowDown") {
-      event.preventDefault();
-      if (!isDropdownOpen) setIsDropdownOpen(true);
-      setHighlightedIndex((prev) =>
-        prev < dropdownItems.length - 1 ? prev + 1 : prev,
-      );
-    } else if (event.key === "ArrowUp") {
-      event.preventDefault();
-      setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : -1));
-    } else if (event.key === "Escape") {
-      setIsDropdownOpen(false);
-      setHighlightedIndex(-1);
-    }
+  const onLabelClose = (labelId: number) => {
+    setLabels(labels.filter((l) => l.id !== labelId));
+  };
+
+  const onEdit = (nextText: string, index: number) => {
+    const copy = [...labels];
+    copy[index] = {
+      ...labels[index],
+      name: nextText,
+      props: {
+        ...labels[index].props,
+        editableProps: {
+          "aria-label": `Editable label with text ${nextText}`,
+        },
+      },
+    };
+    setLabels(copy);
   };
 
   const handleSubmit = async () => {
-    if (selectedLabels.length === 0) return;
+    const labelNames = labels
+      .map((l) => l.name.trim())
+      .filter((name) => name.length > 0);
+    if (labelNames.length === 0) return;
+
+    const uniqueNames = [...new Set(labelNames)];
     setIsSubmitting(true);
     try {
-      await onSubmit(selectedLabels);
+      await onSubmit(uniqueNames);
       onClose();
     } catch (err) {
       console.error("Error adding labels:", err);
@@ -260,10 +110,7 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       variant="medium"
     >
       <ModalHeader title="Add labels" labelId="add-labels-title" />
-      <ModalBody
-        id="add-labels-body"
-        style={{ minHeight: "180px", overflow: "visible" }}
-      >
+      <ModalBody id="add-labels-body" style={{ minHeight: "180px" }}>
         <Content component="p" style={{ marginBottom: "16px" }}>
           Applies to the {selectedVMCount} selected VM
           {selectedVMCount !== 1 ? "s" : ""}. You can add a custom label, or
@@ -274,83 +121,33 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
           <strong>Labels</strong>
         </div>
 
-        <div className={styles.inputWrapper}>
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: focus delegation to inner input */}
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard handled by inner input */}
-          <div
-            className={styles.labelsInput}
-            onClick={() => inputRef.current?.focus()}
-          >
-            {selectedLabels.length > 0 && (
-              <LabelGroup>
-                {selectedLabels.map((label) => (
-                  <Label key={label} onClose={() => removeLabel(label)}>
-                    {label}
-                  </Label>
-                ))}
-              </LabelGroup>
-            )}
-            <TextInput
-              ref={inputRef}
-              type="text"
-              value={inputValue}
-              onChange={handleInputChange}
-              onKeyDown={handleKeyDown}
-              onFocus={() => setIsDropdownOpen(true)}
-              aria-expanded={isDropdownOpen && dropdownItems.length > 0}
-              aria-autocomplete="list"
-              aria-controls="add-labels-suggestions"
-              onBlur={() => {
-                setTimeout(() => setIsDropdownOpen(false), 200);
-              }}
-              className={styles.textInput}
-              aria-label="Type to add labels"
-              placeholder="Search existing or type a new label..."
-            />
-          </div>
-
-          {isDropdownOpen && dropdownItems.length > 0 && (
-            <div
-              id="add-labels-suggestions"
-              className={styles.dropdown}
-              role="listbox"
+        <LabelGroup
+          aria-label="Labels to add"
+          numLabels={20}
+          addLabelControl={
+            <Label variant="add" onClick={onAdd}>
+              Add label
+            </Label>
+          }
+        >
+          {labels.map((label, index) => (
+            <Label
+              key={label.id}
+              onClose={() => onLabelClose(label.id)}
+              onEditCancel={(_event, prevText) => onEdit(prevText, index)}
+              onEditComplete={(_event, newText) => onEdit(newText, index)}
+              {...label.props}
             >
-              {matchingExistingLabels.length > 0 && (
-                <div className={styles.dropdownSection}>Existing labels</div>
-              )}
-              {dropdownItems.map((item, index) => (
-                <button
-                  type="button"
-                  key={`${item.type}-${item.value}`}
-                  role="option"
-                  aria-selected={index === highlightedIndex}
-                  className={
-                    index === highlightedIndex
-                      ? styles.dropdownItemHighlighted
-                      : styles.dropdownItem
-                  }
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    addLabel(item.value);
-                  }}
-                  onMouseEnter={() => setHighlightedIndex(index)}
-                >
-                  {item.type === "create" ? (
-                    <>Create label &quot;{item.value}&quot;</>
-                  ) : (
-                    item.value
-                  )}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+              {label.name}
+            </Label>
+          ))}
+        </LabelGroup>
       </ModalBody>
       <ModalFooter>
         <Button
           variant="primary"
           onClick={handleSubmit}
-          isDisabled={selectedLabels.length === 0 || isSubmitting}
+          isDisabled={labels.length === 0 || isSubmitting}
           isLoading={isSubmitting}
         >
           Add labels

--- a/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
@@ -51,9 +51,10 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
   const [activeItemId, setActiveItemId] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const textInputRef = useRef<HTMLInputElement>(undefined);
+  const prevIsOpenRef = useRef(false);
 
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && !prevIsOpenRef.current) {
       setSelected([...currentVMLabels]);
       setInputValue("");
       setIsSelectOpen(false);
@@ -61,6 +62,7 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       setFocusedItemIndex(null);
       setActiveItemId(null);
     }
+    prevIsOpenRef.current = isOpen;
   }, [isOpen, currentVMLabels]);
 
   useEffect(() => {

--- a/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
@@ -238,7 +238,7 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
         aria-describedby="manage-labels-body"
         variant="medium"
       >
-        <ModalHeader title="Manage labels" labelId="manage-labels-title" />
+        <ModalHeader title="Manage all labels" labelId="manage-labels-title" />
         <ModalBody id="manage-labels-body">
           <Content component="p" style={{ marginBottom: "16px" }}>
             View, rename, or delete labels. Renaming or deleting a label updates

--- a/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
@@ -271,10 +271,6 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
             &quot;Add Labels&quot; action on your virtual machines.
           </Content>
 
-          <div style={{ marginBottom: "8px" }}>
-            <strong>Labels</strong>
-          </div>
-
           {loading ? (
             <Content component="p">Loading labels...</Content>
           ) : labels.length === 0 ? (

--- a/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
@@ -1,0 +1,419 @@
+import { css } from "@emotion/css";
+import {
+  Button,
+  Content,
+  Flex,
+  FlexItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TextInput,
+} from "@patternfly/react-core";
+import {
+  CheckIcon,
+  PencilAltIcon,
+  TimesIcon,
+  TrashIcon,
+} from "@patternfly/react-icons";
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const styles = {
+  labelList: css`
+    width: 100%;
+  `,
+  labelHeader: css`
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 16px;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--pf-t--global--border--color--default);
+    font-weight: 700;
+    font-size: 13px;
+  `,
+  labelRow: css`
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 16px;
+    align-items: center;
+    padding: 12px 0;
+    border-bottom: 1px solid var(--pf-t--global--border--color--default);
+  `,
+  labelRowEditing: css`
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 16px;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--pf-t--global--border--color--default);
+  `,
+  editInputGroup: css`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  `,
+  actionButtons: css`
+    display: flex;
+    gap: 4px;
+  `,
+};
+
+interface LabelInfo {
+  name: string;
+  vmCount: number;
+}
+
+interface PendingRename {
+  oldName: string;
+  newName: string;
+}
+
+interface ManageLabelsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onLabelsChanged: () => void;
+  basePath: string;
+}
+
+export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
+  isOpen,
+  onClose,
+  onLabelsChanged,
+  basePath,
+}) => {
+  const [labels, setLabels] = useState<LabelInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [editingLabel, setEditingLabel] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [deletingLabel, setDeletingLabel] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const pendingDeletes = useRef<string[]>([]);
+  const pendingRenames = useRef<PendingRename[]>([]);
+
+  const fetchLabelsWithCounts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const labelsResponse = await fetch(`${basePath}/vms/labels`);
+      if (!labelsResponse.ok) {
+        setLabels([]);
+        return;
+      }
+      const labelsData = await labelsResponse.json();
+      const labelNames: string[] = labelsData.labels || [];
+
+      const labelCounts: Record<string, number> = {};
+      for (const name of labelNames) {
+        labelCounts[name] = 0;
+      }
+
+      let page = 1;
+      let hasMore = true;
+      while (hasMore) {
+        const vmsResponse = await fetch(
+          `${basePath}/vms?page=${page}&pageSize=1000`,
+        );
+        if (!vmsResponse.ok) break;
+        const vmsData = await vmsResponse.json();
+        const vms: { labels?: string[] }[] = vmsData.vms || [];
+
+        for (const vm of vms) {
+          if (vm.labels) {
+            for (const lbl of vm.labels) {
+              if (lbl in labelCounts) {
+                labelCounts[lbl]++;
+              }
+            }
+          }
+        }
+
+        const total = vmsData.total || 0;
+        hasMore = page * 1000 < total;
+        page++;
+      }
+
+      setLabels(
+        labelNames.map((name) => ({ name, vmCount: labelCounts[name] || 0 })),
+      );
+    } catch (err) {
+      console.error("Error fetching labels:", err);
+      setLabels([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [basePath]);
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchLabelsWithCounts();
+      setEditingLabel(null);
+      setEditValue("");
+      setDeletingLabel(null);
+      pendingDeletes.current = [];
+      pendingRenames.current = [];
+    }
+  }, [isOpen, fetchLabelsWithCounts]);
+
+  const handleDeleteLabel = (labelName: string) => {
+    setLabels((prev) => prev.filter((l) => l.name !== labelName));
+    setDeletingLabel(null);
+    pendingDeletes.current.push(labelName);
+
+    // Remove any pending renames involving this label
+    pendingRenames.current = pendingRenames.current.filter(
+      (r) => r.oldName !== labelName && r.newName !== labelName,
+    );
+  };
+
+  const handleRenameLabel = (oldName: string, newName: string) => {
+    const trimmed = newName.trim();
+    if (!trimmed || trimmed === oldName) {
+      setEditingLabel(null);
+      return;
+    }
+
+    setLabels((prev) =>
+      prev.map((l) => (l.name === oldName ? { ...l, name: trimmed } : l)),
+    );
+    setEditingLabel(null);
+
+    const existingRename = pendingRenames.current.find(
+      (r) => r.newName === oldName,
+    );
+    if (existingRename) {
+      existingRename.newName = trimmed;
+    } else {
+      pendingRenames.current.push({ oldName, newName: trimmed });
+    }
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      // Process deletes
+      for (const labelName of pendingDeletes.current) {
+        await fetch(`${basePath}/vms/labels/${encodeURIComponent(labelName)}`, {
+          method: "DELETE",
+        });
+      }
+
+      // Process renames (get VMs with old label, add new label, delete old)
+      for (const { oldName, newName } of pendingRenames.current) {
+        const vmIds: string[] = [];
+        let page = 1;
+        let hasMore = true;
+        while (hasMore) {
+          const vmsResponse = await fetch(
+            `${basePath}/vms?page=${page}&pageSize=1000`,
+          );
+          if (!vmsResponse.ok) break;
+          const vmsData = await vmsResponse.json();
+          const vms: { id: string; labels?: string[] }[] = vmsData.vms || [];
+          for (const vm of vms) {
+            if (vm.labels?.includes(oldName)) {
+              vmIds.push(vm.id);
+            }
+          }
+          const total = vmsData.total || 0;
+          hasMore = page * 1000 < total;
+          page++;
+        }
+
+        if (vmIds.length > 0) {
+          await fetch(`${basePath}/vms/labels/${encodeURIComponent(newName)}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ add: vmIds }),
+          });
+
+          await fetch(`${basePath}/vms/labels/${encodeURIComponent(oldName)}`, {
+            method: "DELETE",
+          });
+        }
+      }
+
+      pendingDeletes.current = [];
+      pendingRenames.current = [];
+      onLabelsChanged();
+      onClose();
+    } catch (err) {
+      console.error("Error saving labels:", err);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const startEditing = (labelName: string) => {
+    setEditingLabel(labelName);
+    setEditValue(labelName);
+  };
+
+  const cancelEditing = () => {
+    setEditingLabel(null);
+    setEditValue("");
+  };
+
+  return (
+    <>
+      <Modal
+        isOpen={isOpen && !deletingLabel}
+        onClose={onClose}
+        aria-labelledby="manage-labels-title"
+        aria-describedby="manage-labels-body"
+        variant="medium"
+      >
+        <ModalHeader title="Manage labels" labelId="manage-labels-title" />
+        <ModalBody id="manage-labels-body">
+          <Content component="p" style={{ marginBottom: "16px" }}>
+            View, rename, or delete labels. Renaming or deleting a label updates
+            every virtual machine that uses it. To create a new label, use the
+            &quot;Add Labels&quot; action on your virtual machines.
+          </Content>
+
+          <div style={{ marginBottom: "8px" }}>
+            <strong>Labels</strong>
+          </div>
+
+          {loading ? (
+            <Content component="p">Loading labels...</Content>
+          ) : labels.length === 0 ? (
+            <Content component="p">
+              No labels created. Create one by adding a label to one or more
+              virtual machines.
+            </Content>
+          ) : (
+            <div className={styles.labelList}>
+              <div className={styles.labelHeader}>
+                <span>Label</span>
+                <span>VMs</span>
+                <span />
+              </div>
+              {labels.map((label) => (
+                <div
+                  key={label.name}
+                  className={
+                    editingLabel === label.name
+                      ? styles.labelRowEditing
+                      : styles.labelRow
+                  }
+                >
+                  {editingLabel === label.name ? (
+                    <div className={styles.editInputGroup}>
+                      <TextInput
+                        type="text"
+                        value={editValue}
+                        onChange={(_e, value) => setEditValue(value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            handleRenameLabel(label.name, editValue);
+                          } else if (e.key === "Escape") {
+                            cancelEditing();
+                          }
+                        }}
+                        aria-label="Edit label name"
+                        autoFocus
+                      />
+                      <Button
+                        variant="plain"
+                        aria-label="Confirm rename"
+                        onClick={() => handleRenameLabel(label.name, editValue)}
+                      >
+                        <CheckIcon />
+                      </Button>
+                      <Button
+                        variant="plain"
+                        aria-label="Cancel rename"
+                        onClick={cancelEditing}
+                      >
+                        <TimesIcon />
+                      </Button>
+                    </div>
+                  ) : (
+                    <span>{label.name}</span>
+                  )}
+                  <span>{label.vmCount}</span>
+                  {editingLabel !== label.name && (
+                    <div className={styles.actionButtons}>
+                      <Button
+                        variant="plain"
+                        aria-label={`Edit label ${label.name}`}
+                        onClick={() => startEditing(label.name)}
+                      >
+                        <PencilAltIcon />
+                      </Button>
+                      <Button
+                        variant="plain"
+                        aria-label={`Delete label ${label.name}`}
+                        onClick={() => setDeletingLabel(label.name)}
+                      >
+                        <TrashIcon />
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Flex gap={{ default: "gapMd" }}>
+            <FlexItem>
+              <Button
+                variant="primary"
+                onClick={handleSave}
+                isLoading={isSaving}
+                isDisabled={isSaving}
+              >
+                Save
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Button variant="link" onClick={onClose} isDisabled={isSaving}>
+                Cancel
+              </Button>
+            </FlexItem>
+          </Flex>
+        </ModalFooter>
+      </Modal>
+
+      {/* Delete confirmation modal */}
+      <Modal
+        isOpen={!!deletingLabel}
+        onClose={() => setDeletingLabel(null)}
+        aria-labelledby="delete-label-title"
+        aria-describedby="delete-label-body"
+        variant="small"
+      >
+        <ModalHeader title="Delete label?" labelId="delete-label-title" />
+        <ModalBody id="delete-label-body">
+          <Content component="p">
+            Remove label <strong>{deletingLabel}</strong> from the catalog and
+            from every virtual machine that uses it?
+          </Content>
+        </ModalBody>
+        <ModalFooter>
+          <Flex gap={{ default: "gapMd" }}>
+            <FlexItem>
+              <Button
+                variant="danger"
+                onClick={() =>
+                  deletingLabel && handleDeleteLabel(deletingLabel)
+                }
+              >
+                Delete
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Button variant="link" onClick={() => setDeletingLabel(null)}>
+                Cancel
+              </Button>
+            </FlexItem>
+          </Flex>
+        </ModalFooter>
+      </Modal>
+    </>
+  );
+};
+
+ManageLabelsModal.displayName = "ManageLabelsModal";

--- a/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
@@ -102,39 +102,13 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
       }
       const labelsData = await labelsResponse.json();
       const labelNames: string[] = labelsData.labels || [];
-
-      const labelCounts: Record<string, number> = {};
-      for (const name of labelNames) {
-        labelCounts[name] = 0;
-      }
-
-      let page = 1;
-      let hasMore = true;
-      while (hasMore) {
-        const vmsResponse = await fetch(
-          `${basePath}/vms?page=${page}&pageSize=1000`,
-        );
-        if (!vmsResponse.ok) break;
-        const vmsData = await vmsResponse.json();
-        const vms: { labels?: string[] }[] = vmsData.vms || [];
-
-        for (const vm of vms) {
-          if (vm.labels) {
-            for (const lbl of vm.labels) {
-              if (lbl in labelCounts) {
-                labelCounts[lbl]++;
-              }
-            }
-          }
-        }
-
-        const total = vmsData.total || 0;
-        hasMore = page * 1000 < total;
-        page++;
-      }
+      const labelCounts: number[] = labelsData.counts || [];
 
       setLabels(
-        labelNames.map((name) => ({ name, vmCount: labelCounts[name] || 0 })),
+        labelNames.map((name, i) => ({
+          name,
+          vmCount: labelCounts[i] || 0,
+        })),
       );
     } catch (err) {
       console.error("Error fetching labels:", err);
@@ -159,8 +133,6 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
     setLabels((prev) => prev.filter((l) => l.name !== labelName));
     setDeletingLabel(null);
     pendingDeletes.current.push(labelName);
-
-    // Remove any pending renames involving this label
     pendingRenames.current = pendingRenames.current.filter(
       (r) => r.oldName !== labelName && r.newName !== labelName,
     );
@@ -169,6 +141,11 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
   const handleRenameLabel = (oldName: string, newName: string) => {
     const trimmed = newName.trim();
     if (!trimmed || trimmed === oldName) {
+      setEditingLabel(null);
+      return;
+    }
+
+    if (labels.some((l) => l.name === trimmed && l.name !== oldName)) {
       setEditingLabel(null);
       return;
     }
@@ -188,17 +165,25 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
     }
   };
 
+  const startEditing = (labelName: string) => {
+    setEditingLabel(labelName);
+    setEditValue(labelName);
+  };
+
+  const cancelEditing = () => {
+    setEditingLabel(null);
+    setEditValue("");
+  };
+
   const handleSave = async () => {
     setIsSaving(true);
     try {
-      // Process deletes
       for (const labelName of pendingDeletes.current) {
         await fetch(`${basePath}/vms/labels/${encodeURIComponent(labelName)}`, {
           method: "DELETE",
         });
       }
 
-      // Process renames (get VMs with old label, add new label, delete old)
       for (const { oldName, newName } of pendingRenames.current) {
         const vmIds: string[] = [];
         let page = 1;
@@ -226,11 +211,11 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ add: vmIds }),
           });
-
-          await fetch(`${basePath}/vms/labels/${encodeURIComponent(oldName)}`, {
-            method: "DELETE",
-          });
         }
+
+        await fetch(`${basePath}/vms/labels/${encodeURIComponent(oldName)}`, {
+          method: "DELETE",
+        });
       }
 
       pendingDeletes.current = [];
@@ -242,16 +227,6 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
     } finally {
       setIsSaving(false);
     }
-  };
-
-  const startEditing = (labelName: string) => {
-    setEditingLabel(labelName);
-    setEditValue(labelName);
-  };
-
-  const cancelEditing = () => {
-    setEditingLabel(null);
-    setEditValue("");
   };
 
   return (
@@ -267,17 +242,13 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
         <ModalBody id="manage-labels-body">
           <Content component="p" style={{ marginBottom: "16px" }}>
             View, rename, or delete labels. Renaming or deleting a label updates
-            every virtual machine that uses it. To create a new label, use the
-            &quot;Add Labels&quot; action on your virtual machines.
+            every virtual machine that uses it.
           </Content>
 
           {loading ? (
             <Content component="p">Loading labels...</Content>
           ) : labels.length === 0 ? (
-            <Content component="p">
-              No labels created. Create one by adding a label to one or more
-              virtual machines.
-            </Content>
+            <Content component="p">No labels found.</Content>
           ) : (
             <div className={styles.labelList}>
               <div className={styles.labelHeader}>
@@ -353,23 +324,17 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
           )}
         </ModalBody>
         <ModalFooter>
-          <Flex gap={{ default: "gapMd" }}>
-            <FlexItem>
-              <Button
-                variant="primary"
-                onClick={handleSave}
-                isLoading={isSaving}
-                isDisabled={isSaving}
-              >
-                Save
-              </Button>
-            </FlexItem>
-            <FlexItem>
-              <Button variant="link" onClick={onClose} isDisabled={isSaving}>
-                Cancel
-              </Button>
-            </FlexItem>
-          </Flex>
+          <Button
+            variant="primary"
+            onClick={handleSave}
+            isLoading={isSaving}
+            isDisabled={isSaving}
+          >
+            Save
+          </Button>
+          <Button variant="link" onClick={onClose} isDisabled={isSaving}>
+            Cancel
+          </Button>
         </ModalFooter>
       </Modal>
 
@@ -384,8 +349,8 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
         <ModalHeader title="Delete label?" labelId="delete-label-title" />
         <ModalBody id="delete-label-body">
           <Content component="p">
-            Remove label <strong>{deletingLabel}</strong> from the catalog and
-            from every virtual machine that uses it?
+            Remove label <strong>{deletingLabel}</strong> from every virtual
+            machine that uses it?
           </Content>
         </ModalBody>
         <ModalFooter>

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -1655,13 +1655,13 @@ export const VMTable: React.FC<VMTableProps> = ({
                     isDisabled={selectedVMs.size === 0}
                     onClick={() => onAddLabels?.(Array.from(selectedVMs))}
                   >
-                    Edit labels
+                    Add labels
                   </DropdownItem>
                   <DropdownItem
                     key="manage-labels"
                     onClick={() => onManageLabels?.()}
                   >
-                    Manage labels
+                    Manage all labels
                   </DropdownItem>
                   <DropdownItem key="create-group" isDisabled>
                     Create group
@@ -1903,7 +1903,7 @@ export const VMTable: React.FC<VMTableProps> = ({
                       ).labels;
                       if (vmLabels && vmLabels.length > 0) {
                         return (
-                          <LabelGroup numLabels={3}>
+                          <LabelGroup numLabels={5}>
                             {vmLabels.map((lbl: string) => (
                               <Label key={lbl} isCompact>
                                 {lbl}

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -485,6 +485,9 @@ export const VMTable: React.FC<VMTableProps> = ({
   // Selection state
   // const [selectedVMs, setSelectedVMs] = useState<Set<string>>(new Set());
 
+  // Bulk select dropdown state
+  const [isBulkSelectOpen, setIsBulkSelectOpen] = useState(false);
+
   // Row actions dropdown state
   const [openActionMenuId, setOpenActionMenuId] = useState<string | null>(null);
 
@@ -1210,34 +1213,65 @@ export const VMTable: React.FC<VMTableProps> = ({
         <ToolbarContent>
           {selectedVMs.size > 0 && (
             <ToolbarItem>
-              <MenuToggle
-                variant="plainText"
-                splitButtonItems={[
-                  <Checkbox
-                    key="select-all"
-                    id="select-all-vms"
-                    isChecked={
-                      selectedVMs.size === displayVMs.length
-                        ? true
-                        : selectedVMs.size > 0
-                          ? null
-                          : false
-                    }
-                    onChange={(_event, checked) => {
-                      if (checked) {
-                        onSelectionChange?.(
-                          new Set(displayVMs.map((vm) => vm.id)),
-                        );
-                      } else {
-                        onSelectionChange?.(new Set());
-                      }
-                    }}
-                    aria-label="Select all VMs"
-                  />,
-                ]}
+              <Dropdown
+                isOpen={isBulkSelectOpen}
+                onOpenChange={setIsBulkSelectOpen}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() => setIsBulkSelectOpen(!isBulkSelectOpen)}
+                    variant="plainText"
+                    splitButtonItems={[
+                      <Checkbox
+                        key="select-all"
+                        id="select-all-vms"
+                        isChecked={
+                          selectedVMs.size === displayVMs.length
+                            ? true
+                            : selectedVMs.size > 0
+                              ? null
+                              : false
+                        }
+                        onChange={(_event, checked) => {
+                          if (checked) {
+                            onSelectionChange?.(
+                              new Set(displayVMs.map((vm) => vm.id)),
+                            );
+                          } else {
+                            onSelectionChange?.(new Set());
+                          }
+                        }}
+                        aria-label="Select all VMs"
+                      />,
+                    ]}
+                  >
+                    {selectedVMs.size} selected
+                  </MenuToggle>
+                )}
               >
-                {selectedVMs.size} selected
-              </MenuToggle>
+                <DropdownList>
+                  <DropdownItem
+                    key="select-none"
+                    onClick={() => {
+                      onSelectionChange?.(new Set());
+                      setIsBulkSelectOpen(false);
+                    }}
+                  >
+                    Select none (0)
+                  </DropdownItem>
+                  <DropdownItem
+                    key="select-page"
+                    onClick={() => {
+                      onSelectionChange?.(
+                        new Set(displayVMs.map((vm) => vm.id)),
+                      );
+                      setIsBulkSelectOpen(false);
+                    }}
+                  >
+                    Select page ({displayVMs.length})
+                  </DropdownItem>
+                </DropdownList>
+              </Dropdown>
             </ToolbarItem>
           )}
 
@@ -1629,10 +1663,7 @@ export const VMTable: React.FC<VMTableProps> = ({
                   >
                     Manage labels
                   </DropdownItem>
-                  <DropdownItem
-                    key="create-group"
-                    isDisabled={selectedVMs.size === 0}
-                  >
+                  <DropdownItem key="create-group" isDisabled>
                     Create group
                   </DropdownItem>
                   <DropdownItem key="add-to-group" isDisabled>

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -1655,7 +1655,7 @@ export const VMTable: React.FC<VMTableProps> = ({
                     isDisabled={selectedVMs.size === 0}
                     onClick={() => onAddLabels?.(Array.from(selectedVMs))}
                   >
-                    Add labels
+                    Edit labels
                   </DropdownItem>
                   <DropdownItem
                     key="manage-labels"

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -67,7 +67,7 @@ const filterStyles = {
 
   filterGrid: css`
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(8, 1fr);
     gap: 24px;
   `,
 
@@ -119,12 +119,15 @@ interface VMTableProps {
     datacenters: string[];
     concernLabels: string[];
     concernCategories: string[];
+    vmLabels: string[];
   };
   selectedVMs?: Set<string>;
   onSelectionChange?: (selected: Set<string>) => void;
   onRunDeepInspection?: (includeVmId?: string) => void;
   onExcludeFromReports?: (vmIds: string[]) => Promise<void>;
   onIncludeInReports?: (vmIds: string[]) => Promise<void>;
+  onAddLabels?: (vmIds: string[]) => void;
+  onManageLabels?: () => void;
   showExcludedVMs?: boolean;
   onShowExcludedVMsChange?: (show: boolean) => void;
   hasInspectionResults?: boolean;
@@ -135,6 +138,7 @@ interface VMTableProps {
 
 type ColumnKey =
   | "name"
+  | "labels"
   | "vCenterState"
   | "id"
   | "cpuUsage"
@@ -177,6 +181,7 @@ const isBackendSortableColumn = (
 
 const Columns: Record<ColumnKey, string> = {
   name: "Name",
+  labels: "Labels",
   vCenterState: "Status",
   migratable: "Migration Readiness",
   id: "ID",
@@ -198,7 +203,7 @@ const MANDATORY_COLUMNS: ColumnKey[] = ["name"];
 const DEFAULT_VISIBLE_COLUMNS: ColumnKey[] = [...ALL_COLUMN_KEYS];
 
 const VISIBLE_COLUMNS_KEY = "vmTable.visibleColumns";
-const VISIBLE_COLUMNS_VERSION = 4;
+const VISIBLE_COLUMNS_VERSION = 5;
 
 const statusLabels: Record<string, string> = {
   poweredOn: "Powered on",
@@ -287,12 +292,15 @@ export const VMTable: React.FC<VMTableProps> = ({
     datacenters: [],
     concernLabels: [],
     concernCategories: [],
+    vmLabels: [],
   },
   selectedVMs = new Set<string>(),
   onSelectionChange,
   onRunDeepInspection,
   onExcludeFromReports,
   onIncludeInReports,
+  onAddLabels,
+  onManageLabels,
   showExcludedVMs = true,
   onShowExcludedVMsChange,
   hasInspectionResults = false,
@@ -345,6 +353,7 @@ export const VMTable: React.FC<VMTableProps> = ({
   // Filter modal state
   const [isFilterModalOpen, setIsFilterModalOpen] = useState(false);
   const [isConcernSelectOpen, setIsConcernSelectOpen] = useState(false);
+  const [isVmLabelSelectOpen, setIsVmLabelSelectOpen] = useState(false);
 
   // Cancel deep inspection confirmation
   const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
@@ -396,6 +405,9 @@ export const VMTable: React.FC<VMTableProps> = ({
   const [selectedMigrationReadiness, setSelectedMigrationReadiness] = useState<
     string[]
   >(initialFilters?.migrationReadiness || []);
+  const [selectedVmLabels, setSelectedVmLabels] = useState<string[]>(
+    initialFilters?.vmLabels || [],
+  );
   const [selectedConcernLabels, setSelectedConcernLabels] = useState<string[]>(
     initialFilters?.concernLabels || [],
   );
@@ -429,6 +441,9 @@ export const VMTable: React.FC<VMTableProps> = ({
   >([]);
   const [tempSelectedMigrationReadiness, setTempSelectedMigrationReadiness] =
     useState<string[]>([]);
+  const [tempSelectedVmLabels, setTempSelectedVmLabels] = useState<string[]>(
+    [],
+  );
   const [tempSelectedConcernLabels, setTempSelectedConcernLabels] = useState<
     string[]
   >([]);
@@ -460,6 +475,7 @@ export const VMTable: React.FC<VMTableProps> = ({
     setSelectedClusters(initialFilters?.clusters || []);
     setSelectedDatacenters(initialFilters?.datacenters || []);
     setSelectedMigrationReadiness(initialFilters?.migrationReadiness || []);
+    setSelectedVmLabels(initialFilters?.vmLabels || []);
     setSelectedConcernLabels(initialFilters?.concernLabels || []);
     setSelectedConcernCategories(initialFilters?.concernCategories || []);
     setHasIssuesFilter(initialFilters?.hasIssues || false);
@@ -509,6 +525,7 @@ export const VMTable: React.FC<VMTableProps> = ({
   const availableDatacenters = availableFilterOptions.datacenters;
   const availableConcernLabels = availableFilterOptions.concernLabels;
   const availableConcernCategories = availableFilterOptions.concernCategories;
+  const availableVmLabels = availableFilterOptions.vmLabels;
 
   // Track if filter changes come from user interaction (not from URL sync)
   const isUserInteraction = useRef(false);
@@ -534,6 +551,7 @@ export const VMTable: React.FC<VMTableProps> = ({
         selectedClusters.length > 0 ||
         selectedDatacenters.length > 0 ||
         selectedMigrationReadiness.length > 0 ||
+        selectedVmLabels.length > 0 ||
         selectedConcernLabels.length > 0 ||
         selectedConcernCategories.length > 0 ||
         hasIssuesFilter ||
@@ -561,6 +579,7 @@ export const VMTable: React.FC<VMTableProps> = ({
         selectedMigrationReadiness.length > 0
           ? selectedMigrationReadiness
           : undefined,
+      vmLabels: selectedVmLabels.length > 0 ? selectedVmLabels : undefined,
       concernLabels:
         selectedConcernLabels.length > 0 ? selectedConcernLabels : undefined,
       concernCategories:
@@ -583,6 +602,7 @@ export const VMTable: React.FC<VMTableProps> = ({
     selectedClusters,
     selectedDatacenters,
     selectedMigrationReadiness,
+    selectedVmLabels,
     selectedConcernLabels,
     selectedConcernCategories,
     hasIssuesFilter,
@@ -705,6 +725,15 @@ export const VMTable: React.FC<VMTableProps> = ({
       });
     });
 
+    // VM label filters
+    selectedVmLabels.forEach((label) => {
+      filters.push({
+        category: "Label",
+        label,
+        key: `vm-label-${label}`,
+      });
+    });
+
     // Concern categories filters
     selectedConcernCategories.forEach((category) => {
       filters.push({
@@ -755,6 +784,7 @@ export const VMTable: React.FC<VMTableProps> = ({
     selectedClusters,
     selectedDatacenters,
     selectedMigrationReadiness,
+    selectedVmLabels,
     selectedConcernLabels,
     selectedConcernCategories,
     hasIssuesFilter,
@@ -824,6 +854,7 @@ export const VMTable: React.FC<VMTableProps> = ({
     setSelectedClusters(tempSelectedClusters);
     setSelectedDatacenters(tempSelectedDatacenters);
     setSelectedMigrationReadiness(tempSelectedMigrationReadiness);
+    setSelectedVmLabels(tempSelectedVmLabels);
     setSelectedConcernLabels(tempSelectedConcernLabels);
     setSelectedConcernCategories(tempSelectedConcernCategories);
     setHasIssuesFilter(tempHasIssuesFilter);
@@ -833,6 +864,7 @@ export const VMTable: React.FC<VMTableProps> = ({
     onPageChange?.(1, pageSize); // Reset to page 1
     setIsFilterModalOpen(false);
     setIsConcernSelectOpen(false);
+    setIsVmLabelSelectOpen(false);
     // Reset temporary filters after applying
     resetTempFilters();
   };
@@ -841,6 +873,7 @@ export const VMTable: React.FC<VMTableProps> = ({
   const cancelFilterModal = () => {
     setIsFilterModalOpen(false);
     setIsConcernSelectOpen(false);
+    setIsVmLabelSelectOpen(false);
     // Reset temporary filters when canceling
     resetTempFilters();
   };
@@ -851,6 +884,7 @@ export const VMTable: React.FC<VMTableProps> = ({
     setTempSelectedClusters([]);
     setTempSelectedDatacenters([]);
     setTempSelectedMigrationReadiness([]);
+    setTempSelectedVmLabels([]);
     setTempSelectedConcernLabels([]);
     setTempSelectedConcernCategories([]);
     setTempHasIssuesFilter(false);
@@ -868,6 +902,7 @@ export const VMTable: React.FC<VMTableProps> = ({
       setTempSelectedClusters(selectedClusters);
       setTempSelectedDatacenters(selectedDatacenters);
       setTempSelectedMigrationReadiness(selectedMigrationReadiness);
+      setTempSelectedVmLabels(selectedVmLabels);
       setTempSelectedConcernLabels(selectedConcernLabels);
       setTempSelectedConcernCategories(selectedConcernCategories);
       setTempHasIssuesFilter(hasIssuesFilter);
@@ -881,6 +916,7 @@ export const VMTable: React.FC<VMTableProps> = ({
     selectedClusters,
     selectedDatacenters,
     selectedMigrationReadiness,
+    selectedVmLabels,
     selectedConcernLabels,
     selectedConcernCategories,
     hasIssuesFilter,
@@ -927,6 +963,12 @@ export const VMTable: React.FC<VMTableProps> = ({
       prev.includes(concernLabel)
         ? prev.filter((c) => c !== concernLabel)
         : [...prev, concernLabel],
+    );
+  };
+
+  const toggleTempVmLabel = (label: string) => {
+    setTempSelectedVmLabels((prev) =>
+      prev.includes(label) ? prev.filter((l) => l !== label) : [...prev, label],
     );
   };
 
@@ -981,6 +1023,9 @@ export const VMTable: React.FC<VMTableProps> = ({
       setSelectedMigrationReadiness(
         selectedMigrationReadiness.filter((s) => s !== status),
       );
+    } else if (filterKey.startsWith("vm-label-")) {
+      const label = filterKey.replace("vm-label-", "");
+      setSelectedVmLabels(selectedVmLabels.filter((l) => l !== label));
     } else if (filterKey.startsWith("concern-category-")) {
       const category = filterKey.replace("concern-category-", "");
       setSelectedConcernCategories(
@@ -1006,6 +1051,7 @@ export const VMTable: React.FC<VMTableProps> = ({
     setSelectedClusters([]);
     setSelectedDatacenters([]);
     setSelectedMigrationReadiness([]);
+    setSelectedVmLabels([]);
     setSelectedConcernLabels([]);
     setSelectedConcernCategories([]);
     setHasIssuesFilter(false);
@@ -1426,6 +1472,62 @@ export const VMTable: React.FC<VMTableProps> = ({
                         />
                       </div>
                     </div>
+
+                    {/* VM labels column */}
+                    <div>
+                      <h3 className={filterStyles.columnTitle}>Labels</h3>
+                      <div className={filterStyles.checkboxList}>
+                        {availableVmLabels.length > 0 ? (
+                          <Select
+                            isOpen={isVmLabelSelectOpen}
+                            selected={tempSelectedVmLabels}
+                            onSelect={(_event, selection) => {
+                              toggleTempVmLabel(selection as string);
+                            }}
+                            onOpenChange={setIsVmLabelSelectOpen}
+                            toggle={(
+                              toggleRef: React.Ref<MenuToggleElement>,
+                            ) => (
+                              <MenuToggle
+                                ref={toggleRef}
+                                onClick={() =>
+                                  setIsVmLabelSelectOpen(!isVmLabelSelectOpen)
+                                }
+                                isExpanded={isVmLabelSelectOpen}
+                                className={filterStyles.concernSelect}
+                              >
+                                {tempSelectedVmLabels.length === 0
+                                  ? "Select labels..."
+                                  : `${tempSelectedVmLabels.length} selected`}
+                              </MenuToggle>
+                            )}
+                            isScrollable
+                          >
+                            <SelectList>
+                              {availableVmLabels.map((label) => (
+                                <SelectOption
+                                  key={label}
+                                  value={label}
+                                  hasCheckbox
+                                  isSelected={tempSelectedVmLabels.includes(
+                                    label,
+                                  )}
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                  }}
+                                >
+                                  {label}
+                                </SelectOption>
+                              ))}
+                            </SelectList>
+                          </Select>
+                        ) : (
+                          <Content component="small">
+                            No labels available
+                          </Content>
+                        )}
+                      </div>
+                    </div>
                   </div>
 
                   {/* Footer with buttons */}
@@ -1491,7 +1593,6 @@ export const VMTable: React.FC<VMTableProps> = ({
                     onClick={() => setIsActionsMenuOpen(!isActionsMenuOpen)}
                     isExpanded={isActionsMenuOpen}
                     variant="secondary"
-                    isDisabled={selectedVMs.size === 0}
                   >
                     Actions
                   </MenuToggle>
@@ -1515,18 +1616,35 @@ export const VMTable: React.FC<VMTableProps> = ({
                       Include in reports
                     </DropdownItem>
                   )}
-                  <DropdownItem key="add-label">Add label</DropdownItem>
-                  <DropdownItem key="manage-labels">Manage labels</DropdownItem>
-                  <DropdownItem key="create-group">Create group</DropdownItem>
+                  <DropdownItem
+                    key="add-label"
+                    isDisabled={selectedVMs.size === 0}
+                    onClick={() => onAddLabels?.(Array.from(selectedVMs))}
+                  >
+                    Add labels
+                  </DropdownItem>
+                  <DropdownItem
+                    key="manage-labels"
+                    onClick={() => onManageLabels?.()}
+                  >
+                    Manage labels
+                  </DropdownItem>
+                  <DropdownItem
+                    key="create-group"
+                    isDisabled={selectedVMs.size === 0}
+                  >
+                    Create group
+                  </DropdownItem>
                   <DropdownItem key="add-to-group" isDisabled>
                     Add to group
                   </DropdownItem>
                   <Divider key="separator" component="li" />
-                  <DropdownItem key="remove-from-group">
+                  <DropdownItem key="remove-from-group" isDisabled>
                     Remove from group
                   </DropdownItem>
                   <DropdownItem
                     key="reset-deep-inspection"
+                    isDisabled={selectedVMs.size === 0}
                     onClick={() => onResetInspection?.()}
                   >
                     Reset deep inspection
@@ -1635,6 +1753,8 @@ export const VMTable: React.FC<VMTableProps> = ({
                 switch (key) {
                   case "name":
                     return hasInspectionResults ? 15 : 20;
+                  case "labels":
+                    return 15;
                   case "vCenterState":
                     return hasInspectionResults ? 10 : 15;
                   case "migratable":
@@ -1667,6 +1787,9 @@ export const VMTable: React.FC<VMTableProps> = ({
               const getModifier = (key: ColumnKey) => {
                 if (key === "issues" || key === "migratable") {
                   return "fitContent";
+                }
+                if (key === "labels") {
+                  return "wrap";
                 }
                 return "nowrap";
               };
@@ -1739,6 +1862,27 @@ export const VMTable: React.FC<VMTableProps> = ({
                         </Label>
                       </div>
                     )}
+                  </Td>
+                )}
+                {isColumnVisible("labels") && (
+                  <Td dataLabel="Labels">
+                    {(() => {
+                      const vmLabels: string[] | undefined = (
+                        vm as VirtualMachine & { labels?: string[] }
+                      ).labels;
+                      if (vmLabels && vmLabels.length > 0) {
+                        return (
+                          <LabelGroup numLabels={3}>
+                            {vmLabels.map((lbl: string) => (
+                              <Label key={lbl} isCompact>
+                                {lbl}
+                              </Label>
+                            ))}
+                          </LabelGroup>
+                        );
+                      }
+                      return "–";
+                    })()}
                   </Td>
                 )}
                 {isColumnVisible("vCenterState") && (
@@ -1819,6 +1963,9 @@ export const VMTable: React.FC<VMTableProps> = ({
                     popperProps={{ position: "right" }}
                   >
                     <DropdownList>
+                      <DropdownItem key="remove-from-group" isDisabled>
+                        Remove from group
+                      </DropdownItem>
                       {(() => {
                         const vmState = vm.inspectionStatus?.state;
                         if (vmState === "running" || vmState === "pending") {
@@ -1854,6 +2001,27 @@ export const VMTable: React.FC<VMTableProps> = ({
                           </DropdownItem>
                         );
                       })()}
+                      {vm.migrationExcluded ? (
+                        <DropdownItem
+                          key="include-in-reports"
+                          onClick={() => onIncludeInReports?.([vm.id])}
+                        >
+                          Include in reports
+                        </DropdownItem>
+                      ) : (
+                        <DropdownItem
+                          key="exclude-from-reports"
+                          onClick={() => onExcludeFromReports?.([vm.id])}
+                        >
+                          Exclude from reports
+                        </DropdownItem>
+                      )}
+                      <DropdownItem
+                        key="edit-labels"
+                        onClick={() => onAddLabels?.([vm.id])}
+                      >
+                        Edit labels
+                      </DropdownItem>
                       <DropdownItem
                         key="details"
                         onClick={() => onVMClick?.(vm.id)}

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -142,6 +142,12 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     void fetchAvailableLabels();
   }, [fetchAvailableLabels]);
 
+  useEffect(() => {
+    if (isAddLabelsModalOpen) {
+      void fetchAvailableLabels();
+    }
+  }, [isAddLabelsModalOpen, fetchAvailableLabels]);
+
   const handleAddLabels = useCallback(
     (vmIds: string[]) => {
       setAddLabelsVMIds(vmIds);

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -162,6 +162,12 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     return [...labelSet].sort();
   }, [addLabelsVMIds, vms]);
 
+  const selectedVMName = useMemo(() => {
+    if (addLabelsVMIds.length !== 1) return undefined;
+    const vm = vms.find((v) => v.id === addLabelsVMIds[0]);
+    return vm?.name;
+  }, [addLabelsVMIds, vms]);
+
   const handleAddLabels = useCallback(
     (vmIds: string[]) => {
       setAddLabelsVMIds(vmIds);
@@ -402,6 +408,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
         selectedVMCount={addLabelsVMIds.length}
         existingLabels={availableLabels}
         currentVMLabels={currentVMLabels}
+        selectedVMName={selectedVMName}
       />
       <ManageLabelsModal
         isOpen={isManageLabelsModalOpen}

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -148,6 +148,20 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     }
   }, [isAddLabelsModalOpen, fetchAvailableLabels]);
 
+  const currentVMLabels = useMemo(() => {
+    if (addLabelsVMIds.length === 0) return [];
+    const labelSet = new Set<string>();
+    for (const vm of vms) {
+      if (addLabelsVMIds.includes(vm.id)) {
+        const vmLabels = (vm as VirtualMachine & { labels?: string[] }).labels;
+        if (vmLabels) {
+          for (const l of vmLabels) labelSet.add(l);
+        }
+      }
+    }
+    return [...labelSet].sort();
+  }, [addLabelsVMIds, vms]);
+
   const handleAddLabels = useCallback(
     (vmIds: string[]) => {
       setAddLabelsVMIds(vmIds);
@@ -167,23 +181,34 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   }, [fetchAvailableLabels, onRefreshVMs]);
 
   const handleSubmitLabels = useCallback(
-    async (labels: string[]) => {
+    async (labelsToAdd: string[], labelsToRemove: string[]) => {
       const vmIds = addLabelsVMIds;
 
-      await Promise.all(
-        labels.map((label) =>
-          fetch(`${basePath}/vms/labels/${encodeURIComponent(label)}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ add: vmIds }),
-          }).then((res) => {
-            if (!res.ok) {
-              throw new Error(`Failed to add label "${label}": ${res.status}`);
-            }
-          }),
-        ),
+      const addPromises = labelsToAdd.map((label) =>
+        fetch(`${basePath}/vms/labels/${encodeURIComponent(label)}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ add: vmIds }),
+        }).then((res) => {
+          if (!res.ok) {
+            throw new Error(`Failed to add label "${label}": ${res.status}`);
+          }
+        }),
       );
 
+      const removePromises = labelsToRemove.map((label) =>
+        fetch(`${basePath}/vms/labels/${encodeURIComponent(label)}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ remove: vmIds }),
+        }).then((res) => {
+          if (!res.ok) {
+            throw new Error(`Failed to remove label "${label}": ${res.status}`);
+          }
+        }),
+      );
+
+      await Promise.all([...addPromises, ...removePromises]);
       await refreshLabels();
     },
     [addLabelsVMIds, basePath, refreshLabels],
@@ -376,6 +401,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
         onSubmit={handleSubmitLabels}
         selectedVMCount={addLabelsVMIds.length}
         existingLabels={availableLabels}
+        currentVMLabels={currentVMLabels}
       />
       <ManageLabelsModal
         isOpen={isManageLabelsModalOpen}

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -3,8 +3,11 @@ import type {
   VirtualMachine,
 } from "@openshift-migration-advisor/agent-sdk";
 import type React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getAgentApiBasePath } from "../agentApiConfig";
+import { AddLabelsModal } from "./AddLabelsModal";
 import { DeepInspectionModal } from "./DeepInspectionModal";
+import { ManageLabelsModal } from "./ManageLabelsModal";
 import { VMDetailsPage } from "./VMDetailsPage";
 import { VMTable } from "./VMTable";
 import type { VMFilters } from "./vmFilters";
@@ -57,6 +60,7 @@ interface VirtualMachinesViewProps {
     datacenters: string[];
     concernLabels: string[];
     concernCategories: string[];
+    vmLabels: string[];
   };
   agentApi?: DefaultApiInterface;
   onRefreshVMs?: () => void;
@@ -113,6 +117,71 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     hasInspectionResultsRef.current = true;
   }
   const hasInspectionResults = hasInspectionResultsRef.current;
+
+  // Labels state
+  const [isAddLabelsModalOpen, setIsAddLabelsModalOpen] = useState(false);
+  const [isManageLabelsModalOpen, setIsManageLabelsModalOpen] = useState(false);
+  const [addLabelsVMIds, setAddLabelsVMIds] = useState<string[]>([]);
+  const [availableLabels, setAvailableLabels] = useState<string[]>([]);
+
+  const basePath = useMemo(() => getAgentApiBasePath(agentApi), [agentApi]);
+
+  const fetchAvailableLabels = useCallback(async () => {
+    try {
+      const response = await fetch(`${basePath}/vms/labels`);
+      if (response.ok) {
+        const data = await response.json();
+        setAvailableLabels(data.labels || []);
+      }
+    } catch (err) {
+      console.error("Error fetching labels:", err);
+    }
+  }, [basePath]);
+
+  useEffect(() => {
+    void fetchAvailableLabels();
+  }, [fetchAvailableLabels]);
+
+  const handleAddLabels = useCallback(
+    (vmIds: string[]) => {
+      setAddLabelsVMIds(vmIds);
+      void fetchAvailableLabels();
+      setIsAddLabelsModalOpen(true);
+    },
+    [fetchAvailableLabels],
+  );
+
+  const handleManageLabels = useCallback(() => {
+    setIsManageLabelsModalOpen(true);
+  }, []);
+
+  const refreshLabels = useCallback(async () => {
+    await fetchAvailableLabels();
+    onRefreshVMs?.();
+  }, [fetchAvailableLabels, onRefreshVMs]);
+
+  const handleSubmitLabels = useCallback(
+    async (labels: string[]) => {
+      const vmIds = addLabelsVMIds;
+
+      await Promise.all(
+        labels.map((label) =>
+          fetch(`${basePath}/vms/labels/${encodeURIComponent(label)}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ add: vmIds }),
+          }).then((res) => {
+            if (!res.ok) {
+              throw new Error(`Failed to add label "${label}": ${res.status}`);
+            }
+          }),
+        ),
+      );
+
+      await refreshLabels();
+    },
+    [addLabelsVMIds, basePath, refreshLabels],
+  );
 
   const handleVMClick = (vmId: string) => {
     setSelectedVMId(vmId);
@@ -277,6 +346,8 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
         onRunDeepInspection={handleRunDeepInspection}
         onExcludeFromReports={handleExcludeFromReports}
         onIncludeInReports={handleIncludeInReports}
+        onAddLabels={handleAddLabels}
+        onManageLabels={handleManageLabels}
         showExcludedVMs={showExcludedVMs}
         onShowExcludedVMsChange={onShowExcludedVMsChange}
         hasInspectionResults={hasInspectionResults || inspectionActive}
@@ -293,6 +364,19 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
           onInspectionStarted={handleInspectionStarted}
         />
       )}
+      <AddLabelsModal
+        isOpen={isAddLabelsModalOpen}
+        onClose={() => setIsAddLabelsModalOpen(false)}
+        onSubmit={handleSubmitLabels}
+        selectedVMCount={addLabelsVMIds.length}
+        existingLabels={availableLabels}
+      />
+      <ManageLabelsModal
+        isOpen={isManageLabelsModalOpen}
+        onClose={() => setIsManageLabelsModalOpen(false)}
+        onLabelsChanged={refreshLabels}
+        basePath={basePath}
+      />
     </>
   );
 };

--- a/apps/agent-ui/src/pages/Report/components/vmFilters.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmFilters.ts
@@ -8,6 +8,7 @@ export interface VMFilters {
   diskRange?: { min: number; max?: number };
   memoryRange?: { min: number; max?: number };
   migrationReadiness?: string[];
+  vmLabels?: string[];
   concernLabels?: string[];
   concernCategories?: string[];
   showExcludedVMs?: boolean;
@@ -134,9 +135,14 @@ export function filtersToByExpression(filters: VMFilters): string | undefined {
     }
   }
 
+  // VM user-defined labels (array field; use contains; multiple = AND)
+  if (filters.vmLabels && filters.vmLabels.length > 0) {
+    for (const label of filters.vmLabels) {
+      conditions.push(`labels contains '${escapeFilterValue(label)}'`);
+    }
+  }
+
   // Migration readiness filter
-  // Note: The 'migratable' field might not be supported in backend filters
-  // If the backend doesn't support this field, this filter won't work
   if (filters.migrationReadiness && filters.migrationReadiness.length > 0) {
     const hasReady = filters.migrationReadiness.includes("ready");
     const hasNotReady = filters.migrationReadiness.includes("not-ready");
@@ -206,6 +212,10 @@ export function filtersToSearchParams(filters: VMFilters): URLSearchParams {
 
   if (filters.migrationReadiness && filters.migrationReadiness.length > 0) {
     params.set("migrationReadiness", filters.migrationReadiness.join(","));
+  }
+
+  if (filters.vmLabels && filters.vmLabels.length > 0) {
+    params.set("vmLabels", filters.vmLabels.join(","));
   }
 
   if (filters.concernLabels && filters.concernLabels.length > 0) {
@@ -296,6 +306,11 @@ export function searchParamsToFilters(
     filters.migrationReadiness = migrationReadiness.split(",").filter(Boolean);
   }
 
+  const vmLabels = searchParams.get("vmLabels");
+  if (vmLabels) {
+    filters.vmLabels = vmLabels.split(",").filter(Boolean);
+  }
+
   const concernLabels = searchParams.getAll("concernLabels");
   if (concernLabels.length > 0) {
     filters.concernLabels = concernLabels.filter(Boolean);
@@ -322,6 +337,7 @@ export function hasActiveFilters(filters: VMFilters): boolean {
     (filters.clusters && filters.clusters.length > 0) ||
     (filters.datacenters && filters.datacenters.length > 0) ||
     (filters.migrationReadiness && filters.migrationReadiness.length > 0) ||
+    (filters.vmLabels && filters.vmLabels.length > 0) ||
     (filters.concernLabels && filters.concernLabels.length > 0) ||
     (filters.concernCategories && filters.concernCategories.length > 0) ||
     filters.search


### PR DESCRIPTION
Added full labels support for virtual machines, including viewing, adding, and managing labels.

We are using this component: https://www.patternfly.org/components/menus/select/#multiple-typeahead-with-labels

[recording - 2026-05-28T120428.997.webm](https://github.com/user-attachments/assets/975c2c85-4cc7-4c04-8c72-8d5875179fea)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full VM label management: add, edit, delete labels via modals; label-aware bulk and per-row actions.
  * VM label filtering: Labels multi-select filter, applied filter chips, and Labels column in VM table.

* **UI/UX Changes**
  * Removed "Storage offload estimator" tab; first tab now "Assessment report".
  * VMs marked "Excluded" show an Excluded tag.
  * Improved bulk-selection/actions menu; cluster/tab resets now clear VM label filters from the URL.
  * Report page titles update dynamically.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->