### PR TITLE
fix: ECOPROJECT-4629 | the 'Re-run benchmark' button needs to be shown all the time

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOffloadEstimatorModal.tsx
@@ -1941,7 +1941,6 @@ const ResultsStep: React.FC<ResultsStepProps> = ({
                                   Refresh results
                                 </Button>
                                 {onRerun &&
-                                  benchmarkDone &&
                                   forecastStatus?.state !== "running" && (
                                     <Button
                                       variant="link"
@@ -2502,7 +2501,10 @@ export const StorageOffloadTab: React.FC<StorageOffloadTabProps> = ({
         const status = await getForecasterStatus(basePath);
         if (cancelled) return;
         applyPolledStatus(status);
-        if (status.state !== "running") return;
+        if (status.state !== "running") {
+          setBenchmarkDone(true);
+          return;
+        }
 
         // A benchmark is (still) running — possibly a new one started after
         // the previous one completed. Ensure the UI shows progress cards.


### PR DESCRIPTION
[recording - 2026-05-21T143839.603.webm](https://github.com/user-attachments/assets/2db5af3b-e48e-4a03-9403-d61272f56586)
