### PR TITLE
perf: ECOPROJECT-4584 | Use dedicated endpoint for VM filter options

### DIFF
--- a/apps/agent-ui/package.json
+++ b/apps/agent-ui/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.0",
     "@migration-planner-ui/ioc": "workspace:*",
-    "@openshift-migration-advisor/agent-sdk": "0.12.0-645d2fae3eee",
+    "@openshift-migration-advisor/agent-sdk": "0.12.0-bbcf7fe3b88e",
     "@patternfly/react-charts": "^8.0.0",
     "@patternfly/react-core": "^6.4.3",
     "@patternfly/react-icons": "^6.4.0",

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -251,37 +251,6 @@ export const ReportContainer: React.FC = () => {
     };
   }, [agentApi, selectedClusterId]);
 
-  // Compute available concerns and categories from inventory
-  const availableConcerns = useMemo(() => {
-    if (!inventory?.vcenter?.vms) return { labels: [], categories: [] };
-
-    const concerns = new Set<string>();
-    const warnings = inventory.vcenter.vms.migrationWarnings || [];
-    const errors = inventory.vcenter.vms.notMigratableReasons || [];
-
-    // Collect all unique concern labels
-    [...warnings, ...errors].forEach((issue) => {
-      if (issue.label) {
-        concerns.add(issue.label);
-      }
-    });
-
-    // All possible categories according to backend
-    const categories = [
-      "Critical",
-      "Warning",
-      "Information",
-      "Advisory",
-      "Error",
-      "Other",
-    ];
-
-    return {
-      labels: Array.from(concerns).sort(),
-      categories: categories,
-    };
-  }, [inventory]);
-
   // Fetch available filter options once when VMs tab is first accessed
   useEffect(() => {
     if (activeTab !== 1) return;
@@ -290,40 +259,12 @@ export const ReportContainer: React.FC = () => {
 
     const fetchFilterOptions = async () => {
       try {
-        // Fetch all VMs with pagination to get complete lists of clusters and datacenters
-        let allVMs: VirtualMachine[] = [];
-        let page = 1;
-        const pageSize = 1000;
-        let hasMore = true;
-
-        while (hasMore) {
-          const response = await agentApi.getVMs({
-            page,
-            pageSize,
-          });
-
-          const vms = response.vms || [];
-          allVMs = allVMs.concat(vms);
-
-          // Check if there are more pages
-          const total = response.total || 0;
-          hasMore = allVMs.length < total;
-          page++;
-        }
-
-        const clusters = new Set<string>();
-        const datacenters = new Set<string>();
-
-        allVMs.forEach((vm) => {
-          if (vm.cluster) clusters.add(vm.cluster);
-          if (vm.datacenter) datacenters.add(vm.datacenter);
-        });
-
+        const response = await agentApi.getVMsFilterOptions();
         setAvailableFilterOptions({
-          clusters: Array.from(clusters).sort(),
-          datacenters: Array.from(datacenters).sort(),
-          concernLabels: availableConcerns.labels,
-          concernCategories: availableConcerns.categories,
+          clusters: response.clusters || [],
+          datacenters: response.datacenters || [],
+          concernLabels: response.concernLabels || [],
+          concernCategories: response.concernCategories || [],
         });
         setFilterOptionsFetched(true);
       } catch (err) {
@@ -335,7 +276,7 @@ export const ReportContainer: React.FC = () => {
     };
 
     fetchFilterOptions();
-  }, [activeTab, agentApi, filterOptionsFetched, availableConcerns, inventory]);
+  }, [activeTab, agentApi, filterOptionsFetched, inventory]);
 
   // Fetch VMs when Virtual Machines tab is active or filters change
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,7 +564,7 @@ __metadata:
   dependencies:
     "@emotion/css": "npm:^11.13.0"
     "@migration-planner-ui/ioc": "workspace:*"
-    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-645d2fae3eee"
+    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-bbcf7fe3b88e"
     "@patternfly/react-charts": "npm:^8.0.0"
     "@patternfly/react-core": "npm:^6.4.3"
     "@patternfly/react-icons": "npm:^6.4.0"
@@ -607,10 +607,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openshift-migration-advisor/agent-sdk@npm:0.12.0-645d2fae3eee":
-  version: 0.12.0-645d2fae3eee
-  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-645d2fae3eee"
-  checksum: 10c0/82cc2654014a2af7b4826d534a2dd52420a951270cb714a9dbbfffc1ff238473feff2482326965cd102d55729fdb72ec9e3fa2432dc820302d0f9ba0e288f860
+"@openshift-migration-advisor/agent-sdk@npm:0.12.0-bbcf7fe3b88e":
+  version: 0.12.0-bbcf7fe3b88e
+  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-bbcf7fe3b88e"
+  checksum: 10c0/87b3e7bedc1f0f34ea05491ca9e096f08570f74c248a2826a0c1150ed4c3deb63e1023af6067be2d7b6a0aa34e3eb300309e3fe0a720ab9abfeb3d3e1a83b32e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace inefficient pagination approach (fetching all VMs to extract filter values) with new GET /vms/filter-options endpoint.

- Use agentApi.getVMsFilterOptions() instead of getVMs() pagination
- Remove availableConcerns useMemo
- Single API call vs N paginated requests for large inventories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated filter options retrieval in the Virtual Machines tab: options are now fetched directly from the backend API rather than being derived locally. This leads to more consistent, up-to-date filtering and reduces incorrect or missing filter choices.
  * Reduced local pagination/aggregation work on initial VM access, improving load behavior and reliability when opening the Virtual Machines tab.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->