### PR TITLE
fix: ECOPROJECT-4709 | label improvements

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
@@ -365,10 +365,14 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       />
       <ModalBody id="add-labels-body" style={{ minHeight: "220px" }}>
         <Content component="p" style={{ marginBottom: "16px" }}>
-          {mode === "edit" && selectedVMName ? (
-            <>
-              Add or remove labels for <strong>{selectedVMName}</strong>.
-            </>
+          {mode === "edit" ? (
+            selectedVMName ? (
+              <>
+                Add or remove labels for <strong>{selectedVMName}</strong>.
+              </>
+            ) : (
+              "Add or remove labels for this virtual machine."
+            )
           ) : (
             `Applies to the ${selectedVMCount} selected VM${selectedVMCount !== 1 ? "s" : ""}. Add one or more labels. Existing labels on those VMs are not shown and will not be changed.`
           )}

--- a/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/AddLabelsModal.tsx
@@ -32,6 +32,7 @@ interface AddLabelsModalProps {
   existingLabels: string[];
   currentVMLabels?: string[];
   selectedVMName?: string;
+  mode?: "add" | "edit";
 }
 
 export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
@@ -42,6 +43,7 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
   existingLabels,
   currentVMLabels = [],
   selectedVMName,
+  mode = "add",
 }) => {
   const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [inputValue, setInputValue] = useState("");
@@ -55,7 +57,7 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
 
   useEffect(() => {
     if (isOpen && !prevIsOpenRef.current) {
-      setSelected([...currentVMLabels]);
+      setSelected(mode === "edit" ? [...currentVMLabels] : []);
       setInputValue("");
       setIsSelectOpen(false);
       setIsSubmitting(false);
@@ -63,7 +65,7 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       setActiveItemId(null);
     }
     prevIsOpenRef.current = isOpen;
-  }, [isOpen, currentVMLabels]);
+  }, [isOpen, currentVMLabels, mode]);
 
   useEffect(() => {
     let newOptions: SelectOptionProps[];
@@ -268,9 +270,16 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
     textInputRef.current?.focus();
   };
 
-  const labelsToAdd = selected.filter((l) => !currentVMLabels.includes(l));
-  const labelsToRemove = currentVMLabels.filter((l) => !selected.includes(l));
-  const hasChanges = labelsToAdd.length > 0 || labelsToRemove.length > 0;
+  const labelsToAdd =
+    mode === "add"
+      ? selected
+      : selected.filter((l) => !currentVMLabels.includes(l));
+  const labelsToRemove =
+    mode === "add" ? [] : currentVMLabels.filter((l) => !selected.includes(l));
+  const hasChanges =
+    mode === "add"
+      ? selected.length > 0
+      : labelsToAdd.length > 0 || labelsToRemove.length > 0;
 
   const handleSubmit = async () => {
     if (!hasChanges) return;
@@ -303,7 +312,11 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
           id="add-labels-typeahead-input"
           autoComplete="off"
           innerRef={textInputRef}
-          placeholder="Type or select labels..."
+          placeholder={
+            mode === "add"
+              ? "Type or select labels to add..."
+              : "Type or select labels..."
+          }
           {...(activeItemId && { "aria-activedescendant": activeItemId })}
           role="combobox"
           isExpanded={isSelectOpen}
@@ -347,17 +360,17 @@ export const AddLabelsModal: React.FC<AddLabelsModalProps> = ({
       variant="medium"
     >
       <ModalHeader
-        title={selectedVMName ? "Edit labels" : "Add labels"}
+        title={mode === "edit" ? "Edit labels" : "Add labels"}
         labelId="add-labels-title"
       />
       <ModalBody id="add-labels-body" style={{ minHeight: "220px" }}>
         <Content component="p" style={{ marginBottom: "16px" }}>
-          {selectedVMName ? (
+          {mode === "edit" && selectedVMName ? (
             <>
               Add or remove labels for <strong>{selectedVMName}</strong>.
             </>
           ) : (
-            `Applies to the ${selectedVMCount} selected VM${selectedVMCount !== 1 ? "s" : ""}. You can add a custom label, or select an existing label.`
+            `Applies to the ${selectedVMCount} selected VM${selectedVMCount !== 1 ? "s" : ""}. Add one or more labels. Existing labels on those VMs are not shown and will not be changed.`
           )}
         </Content>
 

--- a/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
@@ -19,22 +19,26 @@ import {
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+const VM_COLUMN_WIDTH = "3.5rem";
+const ACTIONS_COLUMN_WIDTH = "4.5rem";
+
 const styles = {
   labelList: css`
     width: 100%;
   `,
   labelHeader: css`
     display: grid;
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: 1fr ${VM_COLUMN_WIDTH} ${ACTIONS_COLUMN_WIDTH};
     gap: 16px;
     padding: 8px 0;
     border-bottom: 1px solid var(--pf-t--global--border--color--default);
     font-weight: 700;
     font-size: 13px;
+    align-items: end;
   `,
   labelRow: css`
     display: grid;
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: 1fr ${VM_COLUMN_WIDTH} ${ACTIONS_COLUMN_WIDTH};
     gap: 16px;
     align-items: center;
     padding: 12px 0;
@@ -42,11 +46,18 @@ const styles = {
   `,
   labelRowEditing: css`
     display: grid;
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: 1fr ${VM_COLUMN_WIDTH} ${ACTIONS_COLUMN_WIDTH};
     gap: 16px;
     align-items: center;
     padding: 8px 0;
     border-bottom: 1px solid var(--pf-t--global--border--color--default);
+  `,
+  vmColumn: css`
+    text-align: left;
+  `,
+  actionsColumn: css`
+    display: flex;
+    justify-content: flex-end;
   `,
   editInputGroup: css`
     display: flex;
@@ -176,6 +187,10 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
   };
 
   const handleSave = async () => {
+    if (editingLabel) {
+      handleRenameLabel(editingLabel, editValue);
+    }
+
     setIsSaving(true);
     try {
       for (const labelName of pendingDeletes.current) {
@@ -242,7 +257,8 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
         <ModalBody id="manage-labels-body">
           <Content component="p" style={{ marginBottom: "16px" }}>
             View, rename, or delete labels. Renaming or deleting a label updates
-            every virtual machine that uses it.
+            every virtual machine that uses it. To create a new label, use the
+            &apos;Add Labels&apos; action on your virtual machines.
           </Content>
 
           {loading ? (
@@ -253,8 +269,8 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
             <div className={styles.labelList}>
               <div className={styles.labelHeader}>
                 <span>Label</span>
-                <span>VMs</span>
-                <span />
+                <span className={styles.vmColumn}>VMs</span>
+                <span className={styles.actionsColumn} aria-hidden="true" />
               </div>
               {labels.map((label) => (
                 <div
@@ -299,9 +315,11 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
                   ) : (
                     <span>{label.name}</span>
                   )}
-                  <span>{label.vmCount}</span>
+                  <span className={styles.vmColumn}>{label.vmCount}</span>
                   {editingLabel !== label.name && (
-                    <div className={styles.actionButtons}>
+                    <div
+                      className={`${styles.actionsColumn} ${styles.actionButtons}`}
+                    >
                       <Button
                         variant="plain"
                         aria-label={`Edit label ${label.name}`}

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -28,6 +28,7 @@ export const VMTable: React.FC<VMTableProps> = ({
   onExcludeFromReports,
   onIncludeInReports,
   onAddLabels,
+  onEditLabels,
   onManageLabels,
   onCreateGroup,
   onAddToGroup,
@@ -105,7 +106,7 @@ export const VMTable: React.FC<VMTableProps> = ({
         onRunDeepInspection={onRunDeepInspection}
         onExcludeFromReports={onExcludeFromReports}
         onIncludeInReports={onIncludeInReports}
-        onAddLabels={onAddLabels}
+        onEditLabels={onEditLabels}
         onAddToGroup={onAddToGroup}
         onRemoveFromGroup={onRemoveFromGroup}
         setIsCancelConfirmOpen={logic.setIsCancelConfirmOpen}

--- a/apps/agent-ui/src/pages/Report/components/VMTableActionBar.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableActionBar.tsx
@@ -12,8 +12,6 @@ import {
   Pagination,
   Spinner,
   Switch,
-  ToolbarContent,
-  ToolbarGroup,
   ToolbarItem,
   Tooltip,
 } from "@patternfly/react-core";
@@ -87,155 +85,149 @@ export const VMTableActionBar: React.FC<VMTableActionBarProps> = ({
   return (
     <>
       {!hideToolbarActions && (
-        <ToolbarContent>
-          <ToolbarGroup>
-            <ToolbarItem>
-              <Dropdown
-                isOpen={isActionsMenuOpen}
-                onSelect={() => setIsActionsMenuOpen(false)}
-                onOpenChange={setIsActionsMenuOpen}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    onClick={() => setIsActionsMenuOpen(!isActionsMenuOpen)}
-                    isExpanded={isActionsMenuOpen}
-                    variant="secondary"
-                  >
-                    Actions
-                  </MenuToggle>
-                )}
-                popperProps={{ position: "right" }}
-              >
-                <DropdownList>
-                  {onExcludeFromReports && selectedIncludedIds.length > 0 && (
-                    <DropdownItem
-                      key="exclude-from-reports"
-                      onClick={() => setIsExcludeModalOpen(true)}
-                    >
-                      Exclude from reports
-                    </DropdownItem>
-                  )}
-                  {onIncludeInReports && selectedExcludedIds.length > 0 && (
-                    <DropdownItem
-                      key="include-in-reports"
-                      onClick={() => setIsIncludeModalOpen(true)}
-                    >
-                      Include in reports
-                    </DropdownItem>
-                  )}
-                  <DropdownItem
-                    key="add-label"
-                    isDisabled={selectedVMs.size === 0}
-                    onClick={() => onAddLabels?.(Array.from(selectedVMs))}
-                  >
-                    Add labels
-                  </DropdownItem>
-                  <DropdownItem
-                    key="manage-labels"
-                    onClick={() => onManageLabels?.()}
-                  >
-                    Manage all labels
-                  </DropdownItem>
-                  {!isGroupRowActions && (
-                    <>
-                      <DropdownItem
-                        key="create-group"
-                        isDisabled={selectedVMs.size === 0 || !onCreateGroup}
-                        onClick={() => onCreateGroup?.(selectedVmIds)}
-                      >
-                        Create group
-                      </DropdownItem>
-                      <DropdownItem
-                        key="add-to-group"
-                        isDisabled={selectedVMs.size === 0 || !onAddToGroup}
-                        onClick={() => onAddToGroup?.(selectedVmIds)}
-                      >
-                        Add to group
-                      </DropdownItem>
-                    </>
-                  )}
-                  <Divider key="separator" component="li" />
-                  <DropdownItem
-                    key="remove-from-group"
-                    isDisabled={
-                      selectedVMs.size === 0 ||
-                      !canRemoveSelectedFromGroup ||
-                      !onRemoveFromGroup
-                    }
-                    onClick={() => onRemoveFromGroup?.(selectedVmIds)}
-                  >
-                    Remove from group
-                  </DropdownItem>
-                  <DropdownItem
-                    key="reset-deep-inspection"
-                    isDisabled={selectedVMs.size === 0}
-                    onClick={() => onResetInspection?.()}
-                  >
-                    Reset deep inspection
-                  </DropdownItem>
-                </DropdownList>
-              </Dropdown>
-            </ToolbarItem>
-
-            <ToolbarItem>
-              <Tooltip content="Select VMs for deep inspection.">
-                <Button
-                  variant="primary"
-                  icon={<MagicIcon />}
-                  isDisabled={selectedVMs.size === 0}
-                  onClick={() => onRunDeepInspection?.()}
+        <>
+          <ToolbarItem>
+            <Dropdown
+              isOpen={isActionsMenuOpen}
+              onSelect={() => setIsActionsMenuOpen(false)}
+              onOpenChange={setIsActionsMenuOpen}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsActionsMenuOpen(!isActionsMenuOpen)}
+                  isExpanded={isActionsMenuOpen}
+                  variant="secondary"
                 >
-                  Run deep inspection
-                </Button>
-              </Tooltip>
-            </ToolbarItem>
-            {inspectionActive && (
-              <ToolbarItem>
-                <Spinner size="md" />
-              </ToolbarItem>
-            )}
-          </ToolbarGroup>
-        </ToolbarContent>
-      )}
-      <ToolbarContent>
-        <ToolbarItem align={{ default: "alignEnd" }}>
-          <Flex
-            alignItems={{ default: "alignItemsCenter" }}
-            gap={{ default: "gapMd" }}
-          >
-            <FlexItem>
-              {loading && vms.length > 0 && <Spinner size="sm" />}
-            </FlexItem>
-            <FlexItem>
-              {onShowExcludedVMsChange && (
-                <Switch
-                  id={showExcludedSwitchId}
-                  label="Show excluded VMs"
-                  isChecked={showExcludedVMs}
-                  onChange={(_event, checked) => {
-                    onShowExcludedVMsChange(checked);
-                  }}
-                />
+                  Actions
+                </MenuToggle>
               )}
-            </FlexItem>
-            <FlexItem>
-              <Pagination
-                itemCount={totalVMs ?? vms.length}
-                perPage={pageSize}
-                page={page}
-                onSetPage={(_event, newPage) =>
-                  onPageChange?.(newPage, pageSize)
-                }
-                onPerPageSelect={(_event, newPerPage) => {
-                  onPageChange?.(1, newPerPage);
+              popperProps={{ position: "right" }}
+            >
+              <DropdownList>
+                {onExcludeFromReports && selectedIncludedIds.length > 0 && (
+                  <DropdownItem
+                    key="exclude-from-reports"
+                    onClick={() => setIsExcludeModalOpen(true)}
+                  >
+                    Exclude from reports
+                  </DropdownItem>
+                )}
+                {onIncludeInReports && selectedExcludedIds.length > 0 && (
+                  <DropdownItem
+                    key="include-in-reports"
+                    onClick={() => setIsIncludeModalOpen(true)}
+                  >
+                    Include in reports
+                  </DropdownItem>
+                )}
+                <DropdownItem
+                  key="add-label"
+                  isDisabled={selectedVMs.size === 0}
+                  onClick={() => onAddLabels?.(Array.from(selectedVMs))}
+                >
+                  Add labels
+                </DropdownItem>
+                <DropdownItem
+                  key="manage-labels"
+                  onClick={() => onManageLabels?.()}
+                >
+                  Manage all labels
+                </DropdownItem>
+                {!isGroupRowActions && (
+                  <>
+                    <DropdownItem
+                      key="create-group"
+                      isDisabled={selectedVMs.size === 0 || !onCreateGroup}
+                      onClick={() => onCreateGroup?.(selectedVmIds)}
+                    >
+                      Create group
+                    </DropdownItem>
+                    <DropdownItem
+                      key="add-to-group"
+                      isDisabled={selectedVMs.size === 0 || !onAddToGroup}
+                      onClick={() => onAddToGroup?.(selectedVmIds)}
+                    >
+                      Add to group
+                    </DropdownItem>
+                  </>
+                )}
+                <Divider key="separator" component="li" />
+                <DropdownItem
+                  key="remove-from-group"
+                  isDisabled={
+                    selectedVMs.size === 0 ||
+                    !canRemoveSelectedFromGroup ||
+                    !onRemoveFromGroup
+                  }
+                  onClick={() => onRemoveFromGroup?.(selectedVmIds)}
+                >
+                  Remove from group
+                </DropdownItem>
+                <DropdownItem
+                  key="reset-deep-inspection"
+                  isDisabled={selectedVMs.size === 0}
+                  onClick={() => onResetInspection?.()}
+                >
+                  Reset deep inspection
+                </DropdownItem>
+              </DropdownList>
+            </Dropdown>
+          </ToolbarItem>
+
+          <ToolbarItem>
+            <Tooltip content="Select VMs for deep inspection.">
+              <Button
+                variant="primary"
+                icon={<MagicIcon />}
+                isDisabled={selectedVMs.size === 0}
+                onClick={() => onRunDeepInspection?.()}
+              >
+                Run deep inspection
+              </Button>
+            </Tooltip>
+          </ToolbarItem>
+          {inspectionActive && (
+            <ToolbarItem>
+              <Spinner size="md" />
+            </ToolbarItem>
+          )}
+        </>
+      )}
+      <ToolbarItem align={{ default: "alignEnd" }}>
+        <Flex
+          alignItems={{ default: "alignItemsCenter" }}
+          gap={{ default: "gapMd" }}
+        >
+          <FlexItem>
+            {loading && vms.length > 0 && <Spinner size="sm" />}
+          </FlexItem>
+          <FlexItem>
+            {onShowExcludedVMsChange && (
+              <Switch
+                id={showExcludedSwitchId}
+                label="Show excluded VMs"
+                isChecked={showExcludedVMs}
+                onChange={(_event, checked) => {
+                  onShowExcludedVMsChange(checked);
                 }}
-                variant="top"
-                isCompact
               />
-            </FlexItem>
-          </Flex>
-        </ToolbarItem>
-      </ToolbarContent>
+            )}
+          </FlexItem>
+          <FlexItem>
+            <Pagination
+              itemCount={totalVMs ?? vms.length}
+              perPage={pageSize}
+              page={page}
+              onSetPage={(_event, newPage) => onPageChange?.(newPage, pageSize)}
+              onPerPageSelect={(_event, newPerPage) => {
+                onPageChange?.(1, newPerPage);
+              }}
+              variant="top"
+              isCompact
+            />
+          </FlexItem>
+        </Flex>
+      </ToolbarItem>
     </>
   );
 };

--- a/apps/agent-ui/src/pages/Report/components/VMTableFilterBar.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableFilterBar.tsx
@@ -42,6 +42,8 @@ export interface VMTableFilterBarProps {
   onFetchAllVmIds?: (
     filters: import("./vmFilters").VMFilters,
   ) => Promise<string[]>;
+  /** "main" = filter controls for the primary toolbar row; "applied" = active filter chips row */
+  part?: "main" | "applied";
 }
 
 export const VMTableFilterBar: React.FC<VMTableFilterBarProps> = ({
@@ -51,6 +53,7 @@ export const VMTableFilterBar: React.FC<VMTableFilterBarProps> = ({
   selectedVMs,
   onSelectionChange,
   onFetchAllVmIds,
+  part = "main",
 }) => {
   const {
     pageVmIds,
@@ -107,441 +110,435 @@ export const VMTableFilterBar: React.FC<VMTableFilterBarProps> = ({
 
   const { showManageColumns } = variantUI;
 
+  if (part === "applied") {
+    if (appliedFilters.length === 0) {
+      return null;
+    }
+
+    return (
+      <ToolbarContent alignItems="center">
+        <ToolbarItem>
+          <LabelGroup categoryName="Filters">
+            {appliedFilters.map((filter) => (
+              <Label key={filter.key} onClose={() => removeFilter(filter.key)}>
+                {filter.label}
+              </Label>
+            ))}
+          </LabelGroup>
+        </ToolbarItem>
+        <ToolbarItem>
+          <span>
+            {appliedFilters.length} filter
+            {appliedFilters.length !== 1 ? "s" : ""} applied
+          </span>
+        </ToolbarItem>
+        <ToolbarItem>
+          <Button variant="link" onClick={clearAllFilters}>
+            Clear all filters
+          </Button>
+        </ToolbarItem>
+      </ToolbarContent>
+    );
+  }
+
   return (
     <>
-      <ToolbarContent>
-        {onSelectionChange && (
-          <ToolbarItem>
-            <Dropdown
-              isOpen={isBulkSelectOpen}
-              onOpenChange={setIsBulkSelectOpen}
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle
-                  ref={toggleRef}
-                  onClick={() => setIsBulkSelectOpen(!isBulkSelectOpen)}
-                  variant="default"
-                  splitButtonItems={[
-                    <Checkbox
-                      key="select-page"
-                      id="select-page-vms"
-                      isChecked={
-                        allPageSelected
-                          ? true
-                          : selectedVMs.size > 0
-                            ? null
-                            : false
+      {onSelectionChange && (
+        <ToolbarItem>
+          <Dropdown
+            isOpen={isBulkSelectOpen}
+            onOpenChange={setIsBulkSelectOpen}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsBulkSelectOpen(!isBulkSelectOpen)}
+                variant="default"
+                splitButtonItems={[
+                  <Checkbox
+                    key="select-page"
+                    id="select-page-vms"
+                    isChecked={
+                      allPageSelected
+                        ? true
+                        : selectedVMs.size > 0
+                          ? null
+                          : false
+                    }
+                    onChange={(_event, checked) => {
+                      if (checked) {
+                        onSelectionChange(new Set(pageVmIds));
+                      } else {
+                        onSelectionChange(new Set());
                       }
-                      onChange={(_event, checked) => {
-                        if (checked) {
-                          onSelectionChange(new Set(pageVmIds));
-                        } else {
-                          onSelectionChange(new Set());
-                        }
-                      }}
-                      aria-label="Select VMs on this page"
-                    />,
-                  ]}
-                />
-              )}
-            >
-              <DropdownList>
-                <DropdownItem
-                  key="select-none"
-                  onClick={() => {
-                    onSelectionChange(new Set());
-                    setIsBulkSelectOpen(false);
-                  }}
-                >
-                  Select none (0 items)
-                </DropdownItem>
-                <DropdownItem
-                  key="select-page"
-                  onClick={() => {
-                    onSelectionChange(new Set(pageVmIds));
-                    setIsBulkSelectOpen(false);
-                  }}
-                >
-                  Select page ({pageVmIds.length} items)
-                </DropdownItem>
-                <DropdownItem
-                  key="select-all"
-                  isDisabled={!onFetchAllVmIds || isSelectingAll}
-                  onClick={() => {
-                    void handleSelectAllMatching();
-                  }}
-                >
-                  {isSelectingAll
-                    ? "Selecting all..."
-                    : `Select all (${totalMatchingCount} items)`}
-                </DropdownItem>
-              </DropdownList>
-            </Dropdown>
-          </ToolbarItem>
-        )}
+                    }}
+                    aria-label="Select VMs on this page"
+                  />,
+                ]}
+              />
+            )}
+          >
+            <DropdownList>
+              <DropdownItem
+                key="select-none"
+                onClick={() => {
+                  onSelectionChange(new Set());
+                  setIsBulkSelectOpen(false);
+                }}
+              >
+                Select none (0 items)
+              </DropdownItem>
+              <DropdownItem
+                key="select-page"
+                onClick={() => {
+                  onSelectionChange(new Set(pageVmIds));
+                  setIsBulkSelectOpen(false);
+                }}
+              >
+                Select page ({pageVmIds.length} items)
+              </DropdownItem>
+              <DropdownItem
+                key="select-all"
+                isDisabled={!onFetchAllVmIds || isSelectingAll}
+                onClick={() => {
+                  void handleSelectAllMatching();
+                }}
+              >
+                {isSelectingAll
+                  ? "Selecting all..."
+                  : `Select all (${totalMatchingCount} items)`}
+              </DropdownItem>
+            </DropdownList>
+          </Dropdown>
+        </ToolbarItem>
+      )}
 
-        <ToolbarGroup variant="filter-group">
-          <ToolbarItem>
-            <SearchInput
-              placeholder="Find by VM name"
-              value={searchValue}
-              onChange={handleSearchChange}
-              onClear={handleSearchClear}
-            />
-          </ToolbarItem>
+      <ToolbarGroup variant="filter-group">
+        <ToolbarItem>
+          <SearchInput
+            placeholder="Find by VM name"
+            value={searchValue}
+            onChange={handleSearchChange}
+            onClear={handleSearchClear}
+          />
+        </ToolbarItem>
 
-          {/* Filters Dropdown */}
-          <ToolbarItem>
-            <Dropdown
-              isOpen={isFilterModalOpen}
-              onOpenChange={setIsFilterModalOpen}
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle
-                  ref={toggleRef}
-                  onClick={() => setIsFilterModalOpen(!isFilterModalOpen)}
-                  isExpanded={isFilterModalOpen}
-                  variant="default"
-                >
-                  <FilterIcon /> Filters
-                </MenuToggle>
-              )}
-              popperProps={{
-                maxWidth: "95vw",
-              }}
-            >
-              <div className={filterStyles.dropdownContent}>
-                <div className={filterStyles.filterGrid}>
-                  {/* Issue categories column */}
-                  <div>
-                    <h3 className={filterStyles.columnTitle}>
-                      Issue categories:
-                    </h3>
-                    <div className={filterStyles.checkboxList}>
-                      {availableConcernCategories.length > 0 &&
-                        availableConcernCategories.map((category) => (
-                          <Checkbox
-                            key={category}
-                            id={`concern-category-${category}`}
-                            label={category}
-                            isChecked={tempSelectedConcernCategories.includes(
-                              category,
-                            )}
-                            onChange={() => {
-                              toggleTempConcernCategory(category);
-                              // Clear has/no issues filters when selecting specific categories
-                              setTempHasIssuesFilter(false);
-                              setTempNoIssuesFilter(false);
-                            }}
-                          />
-                        ))}
-                    </div>
-                  </div>
-
-                  {/* Specific issues column */}
-                  <div>
-                    <h3 className={filterStyles.columnTitle}>
-                      Specific issues
-                    </h3>
-                    <div className={filterStyles.checkboxList}>
-                      {availableConcernLabels.length > 0 && (
-                        <Select
-                          isOpen={isConcernSelectOpen}
-                          selected={tempSelectedConcernLabels}
-                          onSelect={(_event, selection) => {
-                            const concernLabel = selection as string;
-                            toggleTempConcernLabel(concernLabel);
-                            // Clear has/no issues filters when selecting specific concerns
+        {/* Filters Dropdown */}
+        <ToolbarItem>
+          <Dropdown
+            isOpen={isFilterModalOpen}
+            onOpenChange={setIsFilterModalOpen}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsFilterModalOpen(!isFilterModalOpen)}
+                isExpanded={isFilterModalOpen}
+                variant="default"
+              >
+                <FilterIcon /> Filters
+              </MenuToggle>
+            )}
+            popperProps={{
+              maxWidth: "95vw",
+            }}
+          >
+            <div className={filterStyles.dropdownContent}>
+              <div className={filterStyles.filterGrid}>
+                {/* Issue categories column */}
+                <div>
+                  <h3 className={filterStyles.columnTitle}>
+                    Issue categories:
+                  </h3>
+                  <div className={filterStyles.checkboxList}>
+                    {availableConcernCategories.length > 0 &&
+                      availableConcernCategories.map((category) => (
+                        <Checkbox
+                          key={category}
+                          id={`concern-category-${category}`}
+                          label={category}
+                          isChecked={tempSelectedConcernCategories.includes(
+                            category,
+                          )}
+                          onChange={() => {
+                            toggleTempConcernCategory(category);
+                            // Clear has/no issues filters when selecting specific categories
                             setTempHasIssuesFilter(false);
                             setTempNoIssuesFilter(false);
                           }}
-                          onOpenChange={(isOpen) => {
-                            setIsConcernSelectOpen(isOpen);
-                          }}
-                          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                            <MenuToggle
-                              ref={toggleRef}
-                              onClick={() =>
-                                setIsConcernSelectOpen(!isConcernSelectOpen)
-                              }
-                              isExpanded={isConcernSelectOpen}
-                              className={filterStyles.concernSelect}
-                            >
-                              {tempSelectedConcernLabels.length === 0
-                                ? "Select specific issues..."
-                                : `${tempSelectedConcernLabels.length} selected`}
-                            </MenuToggle>
-                          )}
-                          isScrollable
-                        >
-                          <SelectList>
-                            {availableConcernLabels.map((concernLabel) => (
-                              <SelectOption
-                                key={concernLabel}
-                                value={concernLabel}
-                                hasCheckbox
-                                isSelected={tempSelectedConcernLabels.includes(
-                                  concernLabel,
-                                )}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                }}
-                              >
-                                {concernLabel}
-                              </SelectOption>
-                            ))}
-                          </SelectList>
-                        </Select>
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Data center column */}
-                  <div>
-                    <h3 className={filterStyles.columnTitle}>Data center</h3>
-                    <div className={filterStyles.checkboxList}>
-                      {availableDatacenters.map((datacenter) => (
-                        <Checkbox
-                          key={datacenter}
-                          id={`datacenter-${datacenter}`}
-                          label={datacenter}
-                          isChecked={tempSelectedDatacenters.includes(
-                            datacenter,
-                          )}
-                          onChange={() => toggleTempDatacenter(datacenter)}
                         />
                       ))}
-                    </div>
-                  </div>
-
-                  {/* Cluster column */}
-                  <div>
-                    <h3 className={filterStyles.columnTitle}>Cluster</h3>
-                    <div className={filterStyles.checkboxList}>
-                      {availableClusters.map((cluster) => (
-                        <Checkbox
-                          key={cluster}
-                          id={`cluster-${cluster}`}
-                          label={cluster}
-                          isChecked={tempSelectedClusters.includes(cluster)}
-                          onChange={() => toggleTempCluster(cluster)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Disk size column */}
-                  <div>
-                    <h3 className={filterStyles.columnTitle}>Disk size</h3>
-                    <div className={filterStyles.checkboxList}>
-                      {diskSizeRanges.map((range, index) => (
-                        <Checkbox
-                          key={range.label}
-                          id={`disk-${index}`}
-                          label={range.label}
-                          isChecked={
-                            tempDiskRangeFilter?.min === range.min &&
-                            tempDiskRangeFilter?.max === range.max
-                          }
-                          onChange={() => toggleTempDiskRange(index)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Memory size column */}
-                  <div>
-                    <h3 className={filterStyles.columnTitle}>Memory size</h3>
-                    <div className={filterStyles.checkboxList}>
-                      {memorySizeRanges.map((range, index) => (
-                        <Checkbox
-                          key={range.label}
-                          id={`memory-${index}`}
-                          label={range.label}
-                          isChecked={
-                            tempMemoryRangeFilter?.min === range.min &&
-                            tempMemoryRangeFilter?.max === range.max
-                          }
-                          onChange={() => toggleTempMemoryRange(index)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Status column */}
-                  <div>
-                    <h3 className={filterStyles.columnTitle}>Status</h3>
-                    <div className={filterStyles.checkboxList}>
-                      {Object.entries(statusLabels).map(([status, label]) => (
-                        <Checkbox
-                          key={status}
-                          id={`status-${status}`}
-                          label={label}
-                          isChecked={tempSelectedStatuses.includes(status)}
-                          onChange={() => toggleTempStatus(status)}
-                        />
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Migration Readiness column */}
-                  <div>
-                    <h3 className={filterStyles.columnTitle}>
-                      Migration Readiness
-                    </h3>
-                    <div className={filterStyles.checkboxList}>
-                      <Checkbox
-                        id="migration-ready"
-                        label="Ready"
-                        isChecked={tempSelectedMigrationReadiness.includes(
-                          "ready",
-                        )}
-                        onChange={() => toggleTempMigrationReadiness("ready")}
-                      />
-                      <Checkbox
-                        id="migration-not-ready"
-                        label="Not ready"
-                        isChecked={tempSelectedMigrationReadiness.includes(
-                          "not-ready",
-                        )}
-                        onChange={() =>
-                          toggleTempMigrationReadiness("not-ready")
-                        }
-                      />
-                    </div>
-                  </div>
-
-                  {/* VM labels column */}
-                  <div>
-                    <h3 className={filterStyles.columnTitle}>Labels</h3>
-                    <div className={filterStyles.checkboxList}>
-                      {availableVmLabels.length > 0 ? (
-                        <Select
-                          isOpen={isVmLabelSelectOpen}
-                          selected={tempSelectedVmLabels}
-                          onSelect={(_event, selection) => {
-                            toggleTempVmLabel(selection as string);
-                          }}
-                          onOpenChange={setIsVmLabelSelectOpen}
-                          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                            <MenuToggle
-                              ref={toggleRef}
-                              onClick={() =>
-                                setIsVmLabelSelectOpen(!isVmLabelSelectOpen)
-                              }
-                              isExpanded={isVmLabelSelectOpen}
-                              className={filterStyles.concernSelect}
-                            >
-                              {tempSelectedVmLabels.length === 0
-                                ? "Select labels..."
-                                : `${tempSelectedVmLabels.length} selected`}
-                            </MenuToggle>
-                          )}
-                          isScrollable
-                        >
-                          <SelectList>
-                            {availableVmLabels.map((label) => (
-                              <SelectOption
-                                key={label}
-                                value={label}
-                                hasCheckbox
-                                isSelected={tempSelectedVmLabels.includes(
-                                  label,
-                                )}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                }}
-                              >
-                                {label}
-                              </SelectOption>
-                            ))}
-                          </SelectList>
-                        </Select>
-                      ) : (
-                        <Content component="small">No labels available</Content>
-                      )}
-                    </div>
                   </div>
                 </div>
 
-                {/* Footer with buttons */}
-                <div className={filterStyles.footer}>
-                  <Button variant="primary" onClick={applyFilters}>
-                    Apply filters
-                  </Button>
-                  <Button variant="link" onClick={cancelFilterModal}>
-                    Cancel
-                  </Button>
+                {/* Specific issues column */}
+                <div>
+                  <h3 className={filterStyles.columnTitle}>Specific issues</h3>
+                  <div className={filterStyles.checkboxList}>
+                    {availableConcernLabels.length > 0 && (
+                      <Select
+                        isOpen={isConcernSelectOpen}
+                        selected={tempSelectedConcernLabels}
+                        onSelect={(_event, selection) => {
+                          const concernLabel = selection as string;
+                          toggleTempConcernLabel(concernLabel);
+                          // Clear has/no issues filters when selecting specific concerns
+                          setTempHasIssuesFilter(false);
+                          setTempNoIssuesFilter(false);
+                        }}
+                        onOpenChange={(isOpen) => {
+                          setIsConcernSelectOpen(isOpen);
+                        }}
+                        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                          <MenuToggle
+                            ref={toggleRef}
+                            onClick={() =>
+                              setIsConcernSelectOpen(!isConcernSelectOpen)
+                            }
+                            isExpanded={isConcernSelectOpen}
+                            className={filterStyles.concernSelect}
+                          >
+                            {tempSelectedConcernLabels.length === 0
+                              ? "Select specific issues..."
+                              : `${tempSelectedConcernLabels.length} selected`}
+                          </MenuToggle>
+                        )}
+                        isScrollable
+                      >
+                        <SelectList>
+                          {availableConcernLabels.map((concernLabel) => (
+                            <SelectOption
+                              key={concernLabel}
+                              value={concernLabel}
+                              hasCheckbox
+                              isSelected={tempSelectedConcernLabels.includes(
+                                concernLabel,
+                              )}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                              }}
+                            >
+                              {concernLabel}
+                            </SelectOption>
+                          ))}
+                        </SelectList>
+                      </Select>
+                    )}
+                  </div>
+                </div>
+
+                {/* Data center column */}
+                <div>
+                  <h3 className={filterStyles.columnTitle}>Data center</h3>
+                  <div className={filterStyles.checkboxList}>
+                    {availableDatacenters.map((datacenter) => (
+                      <Checkbox
+                        key={datacenter}
+                        id={`datacenter-${datacenter}`}
+                        label={datacenter}
+                        isChecked={tempSelectedDatacenters.includes(datacenter)}
+                        onChange={() => toggleTempDatacenter(datacenter)}
+                      />
+                    ))}
+                  </div>
+                </div>
+
+                {/* Cluster column */}
+                <div>
+                  <h3 className={filterStyles.columnTitle}>Cluster</h3>
+                  <div className={filterStyles.checkboxList}>
+                    {availableClusters.map((cluster) => (
+                      <Checkbox
+                        key={cluster}
+                        id={`cluster-${cluster}`}
+                        label={cluster}
+                        isChecked={tempSelectedClusters.includes(cluster)}
+                        onChange={() => toggleTempCluster(cluster)}
+                      />
+                    ))}
+                  </div>
+                </div>
+
+                {/* Disk size column */}
+                <div>
+                  <h3 className={filterStyles.columnTitle}>Disk size</h3>
+                  <div className={filterStyles.checkboxList}>
+                    {diskSizeRanges.map((range, index) => (
+                      <Checkbox
+                        key={range.label}
+                        id={`disk-${index}`}
+                        label={range.label}
+                        isChecked={
+                          tempDiskRangeFilter?.min === range.min &&
+                          tempDiskRangeFilter?.max === range.max
+                        }
+                        onChange={() => toggleTempDiskRange(index)}
+                      />
+                    ))}
+                  </div>
+                </div>
+
+                {/* Memory size column */}
+                <div>
+                  <h3 className={filterStyles.columnTitle}>Memory size</h3>
+                  <div className={filterStyles.checkboxList}>
+                    {memorySizeRanges.map((range, index) => (
+                      <Checkbox
+                        key={range.label}
+                        id={`memory-${index}`}
+                        label={range.label}
+                        isChecked={
+                          tempMemoryRangeFilter?.min === range.min &&
+                          tempMemoryRangeFilter?.max === range.max
+                        }
+                        onChange={() => toggleTempMemoryRange(index)}
+                      />
+                    ))}
+                  </div>
+                </div>
+
+                {/* Status column */}
+                <div>
+                  <h3 className={filterStyles.columnTitle}>Status</h3>
+                  <div className={filterStyles.checkboxList}>
+                    {Object.entries(statusLabels).map(([status, label]) => (
+                      <Checkbox
+                        key={status}
+                        id={`status-${status}`}
+                        label={label}
+                        isChecked={tempSelectedStatuses.includes(status)}
+                        onChange={() => toggleTempStatus(status)}
+                      />
+                    ))}
+                  </div>
+                </div>
+
+                {/* Migration Readiness column */}
+                <div>
+                  <h3 className={filterStyles.columnTitle}>
+                    Migration Readiness
+                  </h3>
+                  <div className={filterStyles.checkboxList}>
+                    <Checkbox
+                      id="migration-ready"
+                      label="Ready"
+                      isChecked={tempSelectedMigrationReadiness.includes(
+                        "ready",
+                      )}
+                      onChange={() => toggleTempMigrationReadiness("ready")}
+                    />
+                    <Checkbox
+                      id="migration-not-ready"
+                      label="Not ready"
+                      isChecked={tempSelectedMigrationReadiness.includes(
+                        "not-ready",
+                      )}
+                      onChange={() => toggleTempMigrationReadiness("not-ready")}
+                    />
+                  </div>
+                </div>
+
+                {/* VM labels column */}
+                <div>
+                  <h3 className={filterStyles.columnTitle}>Labels</h3>
+                  <div className={filterStyles.checkboxList}>
+                    {availableVmLabels.length > 0 ? (
+                      <Select
+                        isOpen={isVmLabelSelectOpen}
+                        selected={tempSelectedVmLabels}
+                        onSelect={(_event, selection) => {
+                          toggleTempVmLabel(selection as string);
+                        }}
+                        onOpenChange={setIsVmLabelSelectOpen}
+                        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                          <MenuToggle
+                            ref={toggleRef}
+                            onClick={() =>
+                              setIsVmLabelSelectOpen(!isVmLabelSelectOpen)
+                            }
+                            isExpanded={isVmLabelSelectOpen}
+                            className={filterStyles.concernSelect}
+                          >
+                            {tempSelectedVmLabels.length === 0
+                              ? "Select labels..."
+                              : `${tempSelectedVmLabels.length} selected`}
+                          </MenuToggle>
+                        )}
+                        isScrollable
+                      >
+                        <SelectList>
+                          {availableVmLabels.map((label) => (
+                            <SelectOption
+                              key={label}
+                              value={label}
+                              hasCheckbox
+                              isSelected={tempSelectedVmLabels.includes(label)}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                              }}
+                            >
+                              {label}
+                            </SelectOption>
+                          ))}
+                        </SelectList>
+                      </Select>
+                    ) : (
+                      <Content component="small">No labels available</Content>
+                    )}
+                  </div>
                 </div>
               </div>
-            </Dropdown>
-          </ToolbarItem>
 
-          {/* Manage Columns */}
-          {showManageColumns && (
-            <ToolbarItem>
-              <Select
-                role="menu"
-                isOpen={isColumnSelectOpen}
-                onSelect={(_event, selection) => {
-                  toggleColumn(selection as ColumnKey);
-                }}
-                onOpenChange={setIsColumnSelectOpen}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                  <MenuToggle
-                    ref={toggleRef}
-                    onClick={() => setIsColumnSelectOpen((prev) => !prev)}
-                    isExpanded={isColumnSelectOpen}
-                  >
-                    <ColumnsIcon /> Manage columns
-                  </MenuToggle>
-                )}
-              >
-                <SelectList>
-                  {ALL_COLUMN_KEYS.filter(
-                    (key) => key !== "deepInspection" || hasInspectionResults,
-                  ).map((key) => (
-                    <SelectOption
-                      key={key}
-                      value={key}
-                      hasCheckbox
-                      isSelected={isColumnVisible(key)}
-                      isDisabled={MANDATORY_COLUMNS.includes(key)}
-                    >
-                      {Columns[key]}
-                    </SelectOption>
-                  ))}
-                </SelectList>
-              </Select>
-            </ToolbarItem>
-          )}
-        </ToolbarGroup>
-      </ToolbarContent>
-      {appliedFilters.length > 0 && (
-        <ToolbarContent alignItems="center">
+              {/* Footer with buttons */}
+              <div className={filterStyles.footer}>
+                <Button variant="primary" onClick={applyFilters}>
+                  Apply filters
+                </Button>
+                <Button variant="link" onClick={cancelFilterModal}>
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          </Dropdown>
+        </ToolbarItem>
+
+        {/* Manage Columns */}
+        {showManageColumns && (
           <ToolbarItem>
-            <LabelGroup categoryName="Filters">
-              {appliedFilters.map((filter) => (
-                <Label
-                  key={filter.key}
-                  onClose={() => removeFilter(filter.key)}
+            <Select
+              role="menu"
+              isOpen={isColumnSelectOpen}
+              onSelect={(_event, selection) => {
+                toggleColumn(selection as ColumnKey);
+              }}
+              onOpenChange={setIsColumnSelectOpen}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsColumnSelectOpen((prev) => !prev)}
+                  isExpanded={isColumnSelectOpen}
                 >
-                  {filter.label}
-                </Label>
-              ))}
-            </LabelGroup>
+                  <ColumnsIcon /> Manage columns
+                </MenuToggle>
+              )}
+            >
+              <SelectList>
+                {ALL_COLUMN_KEYS.filter(
+                  (key) => key !== "deepInspection" || hasInspectionResults,
+                ).map((key) => (
+                  <SelectOption
+                    key={key}
+                    value={key}
+                    hasCheckbox
+                    isSelected={isColumnVisible(key)}
+                    isDisabled={MANDATORY_COLUMNS.includes(key)}
+                  >
+                    {Columns[key]}
+                  </SelectOption>
+                ))}
+              </SelectList>
+            </Select>
           </ToolbarItem>
-          <ToolbarItem>
-            <span>
-              {appliedFilters.length} filter
-              {appliedFilters.length !== 1 ? "s" : ""} applied
-            </span>
-          </ToolbarItem>
-          <ToolbarItem>
-            <Button variant="link" onClick={clearAllFilters}>
-              Clear all filters
-            </Button>
-          </ToolbarItem>
-        </ToolbarContent>
-      )}
+        )}
+      </ToolbarGroup>
     </>
   );
 };

--- a/apps/agent-ui/src/pages/Report/components/VMTableGrid.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableGrid.tsx
@@ -37,7 +37,7 @@ export interface VMTableGridProps {
   onRunDeepInspection?: (includeVmId?: string) => void;
   onExcludeFromReports?: (vmIds: string[]) => Promise<void>;
   onIncludeInReports?: (vmIds: string[]) => Promise<void>;
-  onAddLabels?: (vmIds: string[]) => void;
+  onEditLabels?: (vmIds: string[]) => void;
   onAddToGroup?: (vmIds: string[]) => void;
   onRemoveFromGroup?: (vmIds: string[]) => void;
   setIsCancelConfirmOpen: (open: boolean) => void;
@@ -55,7 +55,7 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
   onRunDeepInspection,
   onExcludeFromReports,
   onIncludeInReports,
-  onAddLabels,
+  onEditLabels,
   onAddToGroup,
   onRemoveFromGroup,
   setIsCancelConfirmOpen,
@@ -394,7 +394,7 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
                       )}
                       <DropdownItem
                         key="edit-labels"
-                        onClick={() => onAddLabels?.([vm.id])}
+                        onClick={() => onEditLabels?.([vm.id])}
                       >
                         Edit labels
                       </DropdownItem>

--- a/apps/agent-ui/src/pages/Report/components/VMTableToolbar.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableToolbar.tsx
@@ -1,4 +1,4 @@
-import { Toolbar } from "@patternfly/react-core";
+import { Toolbar, ToolbarContent } from "@patternfly/react-core";
 import type React from "react";
 import { VMTableActionBar } from "./VMTableActionBar";
 import { VMTableFilterBar } from "./VMTableFilterBar";
@@ -33,38 +33,45 @@ export const VMTableToolbar: React.FC<VMTableToolbarProps> = (props) => {
     onResetInspection,
   } = props;
 
+  const filterBarProps = {
+    logic,
+    variantUI,
+    hasInspectionResults,
+    selectedVMs,
+    onSelectionChange,
+    onFetchAllVmIds,
+  };
+
+  const actionBarProps = {
+    logic,
+    variantUI,
+    loading,
+    vms,
+    totalVMs,
+    selectedVMs,
+    showExcludedVMs,
+    onShowExcludedVMsChange,
+    onPageChange,
+    inspectionActive,
+    isGroupRowActions,
+    onExcludeFromReports,
+    onIncludeInReports,
+    onAddLabels,
+    onManageLabels,
+    onCreateGroup,
+    onAddToGroup,
+    onRemoveFromGroup,
+    onRunDeepInspection,
+    onResetInspection,
+  };
+
   return (
     <Toolbar>
-      <VMTableFilterBar
-        logic={logic}
-        variantUI={variantUI}
-        hasInspectionResults={hasInspectionResults}
-        selectedVMs={selectedVMs}
-        onSelectionChange={onSelectionChange}
-        onFetchAllVmIds={onFetchAllVmIds}
-      />
-      <VMTableActionBar
-        logic={logic}
-        variantUI={variantUI}
-        loading={loading}
-        vms={vms}
-        totalVMs={totalVMs}
-        selectedVMs={selectedVMs}
-        showExcludedVMs={showExcludedVMs}
-        onShowExcludedVMsChange={onShowExcludedVMsChange}
-        onPageChange={onPageChange}
-        inspectionActive={inspectionActive}
-        isGroupRowActions={isGroupRowActions}
-        onExcludeFromReports={onExcludeFromReports}
-        onIncludeInReports={onIncludeInReports}
-        onAddLabels={onAddLabels}
-        onManageLabels={onManageLabels}
-        onCreateGroup={onCreateGroup}
-        onAddToGroup={onAddToGroup}
-        onRemoveFromGroup={onRemoveFromGroup}
-        onRunDeepInspection={onRunDeepInspection}
-        onResetInspection={onResetInspection}
-      />
+      <ToolbarContent>
+        <VMTableFilterBar {...filterBarProps} part="main" />
+        <VMTableActionBar {...actionBarProps} />
+      </ToolbarContent>
+      <VMTableFilterBar {...filterBarProps} part="applied" />
     </Toolbar>
   );
 };

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -144,6 +144,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
 
   // Labels state
   const [isAddLabelsModalOpen, setIsAddLabelsModalOpen] = useState(false);
+  const [addLabelsMode, setAddLabelsMode] = useState<"add" | "edit">("add");
   const [isManageLabelsModalOpen, setIsManageLabelsModalOpen] = useState(false);
   const [addLabelsVMIds, setAddLabelsVMIds] = useState<string[]>([]);
   const [availableLabels, setAvailableLabels] = useState<string[]>([]);
@@ -233,6 +234,17 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   const handleAddLabels = useCallback(
     (vmIds: string[]) => {
       setAddLabelsVMIds(vmIds);
+      setAddLabelsMode("add");
+      void fetchAvailableLabels();
+      setIsAddLabelsModalOpen(true);
+    },
+    [fetchAvailableLabels],
+  );
+
+  const handleEditLabels = useCallback(
+    (vmIds: string[]) => {
+      setAddLabelsVMIds(vmIds);
+      setAddLabelsMode("edit");
       void fetchAvailableLabels();
       setIsAddLabelsModalOpen(true);
     },
@@ -522,6 +534,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
         onExcludeFromReports={handleExcludeFromReports}
         onIncludeInReports={handleIncludeInReports}
         onAddLabels={handleAddLabels}
+        onEditLabels={handleEditLabels}
         onManageLabels={handleManageLabels}
         onCreateGroup={
           agentApi && effectiveRowActionsVariant === "overview"
@@ -560,6 +573,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
         existingLabels={availableLabels}
         currentVMLabels={currentVMLabels}
         selectedVMName={selectedVMName}
+        mode={addLabelsMode}
       />
       <ManageLabelsModal
         isOpen={isManageLabelsModalOpen}

--- a/apps/agent-ui/src/pages/Report/components/vmTableTypes.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmTableTypes.ts
@@ -31,6 +31,7 @@ export interface VMTableProps {
   onExcludeFromReports?: (vmIds: string[]) => Promise<void>;
   onIncludeInReports?: (vmIds: string[]) => Promise<void>;
   onAddLabels?: (vmIds: string[]) => void;
+  onEditLabels?: (vmIds: string[]) => void;
   onManageLabels?: () => void;
   onCreateGroup?: (vmIds: string[]) => void;
   onAddToGroup?: (vmIds: string[]) => void;


### PR DESCRIPTION
- 'Add labels' modal -  no longer pre-fills the VM's current labels
- 'Edit labels' modal - still loads the VM's labels so users can add or remove them
- 'Manage all labels' modal - fix issue with layout header and change description

[recording - 2026-05-29T122231.537.webm](https://github.com/user-attachments/assets/71b4378d-cb69-494f-8e9a-e50d4650a52e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distinct Add vs Edit label workflows: Add starts empty; Edit preselects a VM's existing labels.
  * Modal header, descriptions, and input placeholders now change by mode.
  * VM table can trigger label editing directly; label table layout uses fixed-width columns for consistency.
  * Clarified guidance about creating labels via "Add Labels".

* **Bug Fixes**
  * Ensured pending label rename is applied before saving.
  * Edit action is correctly disabled when unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/migration-planner-agent-ui/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->