### PR TITLE
fix: solving visual flicker when user search in groups list

### DIFF
--- a/apps/agent-ui/src/pages/Report/GroupsPage.tsx
+++ b/apps/agent-ui/src/pages/Report/GroupsPage.tsx
@@ -74,9 +74,8 @@ export const GroupsPage: React.FC = () => {
   const [editingGroup, setEditingGroup] = useState<Group | null>(null);
   const [deletingGroup, setDeletingGroup] = useState<Group | null>(null);
   const requestIdRef = useRef(0);
-  const hasGroupsRef = useRef(false);
-  hasGroupsRef.current = groups.length > 0;
 
+  // Debounce search input so API calls use debouncedNameFilter, not nameFilter.
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedNameFilter(nameFilter.trim());
@@ -90,10 +89,6 @@ export const GroupsPage: React.FC = () => {
     const requestId = requestIdRef.current;
 
     try {
-      if (!hasGroupsRef.current) {
-        setLoading(true);
-      }
-
       if (selectedLabels.length > 0) {
         const allRaw = await fetchAllGroups(agentApi, {
           byName: debouncedNameFilter || undefined,
@@ -153,6 +148,8 @@ export const GroupsPage: React.FC = () => {
     }
   }, [agentApi, debouncedNameFilter, page, pageSize, selectedLabels]);
 
+  // Refetch when debounced search, pagination, or label filters change — not on each keystroke.
+  // loading is only true on initial mount; refetches keep the current list visible until new data arrives.
   useEffect(() => {
     fetchGroups();
   }, [fetchGroups]);

--- a/apps/agent-ui/src/pages/Report/GroupsPage.tsx
+++ b/apps/agent-ui/src/pages/Report/GroupsPage.tsx
@@ -74,6 +74,8 @@ export const GroupsPage: React.FC = () => {
   const [editingGroup, setEditingGroup] = useState<Group | null>(null);
   const [deletingGroup, setDeletingGroup] = useState<Group | null>(null);
   const requestIdRef = useRef(0);
+  const hasGroupsRef = useRef(false);
+  hasGroupsRef.current = groups.length > 0;
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -88,7 +90,9 @@ export const GroupsPage: React.FC = () => {
     const requestId = requestIdRef.current;
 
     try {
-      setLoading(true);
+      if (!hasGroupsRef.current) {
+        setLoading(true);
+      }
 
       if (selectedLabels.length > 0) {
         const allRaw = await fetchAllGroups(agentApi, {

--- a/apps/agent-ui/src/pages/Report/components/CreateGroupFromSelectionModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/CreateGroupFromSelectionModal.tsx
@@ -97,6 +97,10 @@ export const CreateGroupFromSelectionModal: React.FC<
             />
           </FormGroup>
         </Form>
+        <Content component="p" style={{ marginTop: "16px" }}>
+          A targeted assessment report will be generated for the group of
+          virtual machines created.
+        </Content>
         {error && (
           <Content
             component="p"

--- a/apps/agent-ui/src/pages/Report/components/CreateGroupFromSelectionModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/CreateGroupFromSelectionModal.tsx
@@ -83,6 +83,10 @@ export const CreateGroupFromSelectionModal: React.FC<
           Create a group with the {vmIds.length} selected virtual machine
           {vmIds.length === 1 ? "" : "s"}.
         </Content>
+        <Content component="p" style={{ marginTop: "16px" }}>
+          A targeted assessment report will be generated for the group of
+          virtual machines created.
+        </Content>
         <Form>
           <FormGroup
             label="Group name"
@@ -97,10 +101,6 @@ export const CreateGroupFromSelectionModal: React.FC<
             />
           </FormGroup>
         </Form>
-        <Content component="p" style={{ marginTop: "16px" }}>
-          A targeted assessment report will be generated for the group of
-          virtual machines created.
-        </Content>
         {error && (
           <Content
             component="p"

--- a/apps/agent-ui/src/pages/Report/components/GroupsTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/GroupsTable.tsx
@@ -209,7 +209,7 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({
           </Tr>
         </Thead>
         <Tbody>
-          {loading ? (
+          {loading && groups.length === 0 ? (
             <Tr>
               <Td colSpan={5}>Loading groups...</Td>
             </Tr>

--- a/apps/agent-ui/src/pages/Report/components/GroupsTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/GroupsTable.tsx
@@ -209,7 +209,7 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({
           </Tr>
         </Thead>
         <Tbody>
-          {loading && groups.length === 0 ? (
+          {loading ? (
             <Tr>
               <Td colSpan={5}>Loading groups...</Td>
             </Tr>


### PR DESCRIPTION
- While the user types, the list stays as-is until the debounced fetch finishes and new data arrives
- Adding more info in the 'Create group' modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading indicator behavior on the Groups page to prevent unnecessary re-enabling during data fetches.

* **Documentation**
  * Enhanced group creation modal with additional clarification about generating targeted assessment reports for selected virtual machine groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->