### PR TITLE
fix: ECOPROJECT-4688 | Add CPU max and mem max in VMs list

### DIFF
--- a/apps/agent-ui/package.json
+++ b/apps/agent-ui/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.0",
     "@migration-planner-ui/ioc": "workspace:*",
-    "@openshift-migration-advisor/agent-sdk": "0.12.0-a3d6bdc8bce2",
+    "@openshift-migration-advisor/agent-sdk": "0.12.0-f90a4cad59fa",
     "@patternfly/react-charts": "^8.0.0",
     "@patternfly/react-core": "^6.4.3",
     "@patternfly/react-icons": "^6.4.0",

--- a/apps/agent-ui/src/pages/Report/components/VMTableGrid.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableGrid.tsx
@@ -20,8 +20,11 @@ import {
   renderVmInspectionStatus,
   renderVmStatus,
 } from "./vmTableCellRenderers";
-import type { ColumnKey } from "./vmTableShared";
-import { formatDiskSize, formatMemorySize } from "./vmTableShared";
+import {
+  formatDiskSize,
+  formatMemorySize,
+  getColumnModifier,
+} from "./vmTableShared";
 import type { VMTableLogic } from "./vmTableTypes";
 import type { VMTableVariantUI } from "./vmTableVariants";
 
@@ -82,69 +85,19 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
       <Thead>
         <Tr>
           <Th screenReaderText="Select" />
-          {columns.map((column, index) => {
-            const getWidth = (key: ColumnKey) => {
-              switch (key) {
-                case "name":
-                  return hasInspectionResults ? 15 : 20;
-                case "labels":
-                  return 15;
-                case "groups":
-                  return 15;
-                case "vCenterState":
-                  return hasInspectionResults ? 10 : 15;
-                case "migratable":
-                  return hasInspectionResults ? 10 : 15;
-                case "id":
-                  return hasInspectionResults ? 10 : 15;
-                case "datacenter":
-                  return 10;
-                case "cluster":
-                  return 10;
-                case "diskSize":
-                  return 10;
-                case "memory":
-                  return 10;
-                case "issues":
-                  return 10;
-                case "cpuUsage":
-                  return 10;
-                case "diskUsage":
-                  return 10;
-                case "ramUsage":
-                  return 10;
-                case "deepInspection":
-                  return 15;
-                default:
-                  return undefined;
+          {columns.map((column, index) => (
+            <Th
+              key={column.key}
+              sort={
+                column.sortable ? getSortParams(column.key, index) : undefined
               }
-            };
-
-            const getModifier = (key: ColumnKey) => {
-              if (key === "issues" || key === "migratable") {
-                return "fitContent";
-              }
-              if (key === "labels") {
-                return "wrap";
-              }
-              return "nowrap";
-            };
-
-            return (
-              <Th
-                key={column.key}
-                sort={
-                  column.sortable ? getSortParams(column.key, index) : undefined
-                }
-                width={getWidth(column.key)}
-                modifier={getModifier(column.key)}
-              >
-                {column.label}
-              </Th>
-            );
-          })}
+              modifier={getColumnModifier(column.key)}
+            >
+              {column.label}
+            </Th>
+          ))}
           {!hideToolbarActions && (
-            <Th width={10} modifier="fitContent" screenReaderText="Actions" />
+            <Th modifier="fitContent" screenReaderText="Actions" />
           )}
         </Tr>
       </Thead>
@@ -262,19 +215,20 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
                 </Td>
               )}
               {isColumnVisible("id") && <Td dataLabel="ID">{vm.id}</Td>}
-              {isColumnVisible("cpuUsage") && (
-                <Td dataLabel="CPU usage" modifier="fitContent">
-                  {formatMetric(vm.utilization_cpu_p95)}
+
+              {isColumnVisible("maxCPU") && (
+                <Td dataLabel="Max CPU" modifier="fitContent">
+                  {formatMetric(vm.utilization_cpu_max)}
+                </Td>
+              )}
+              {isColumnVisible("maxRAM") && (
+                <Td dataLabel="Max RAM" modifier="fitContent">
+                  {formatMetric(vm.utilization_mem_max)}
                 </Td>
               )}
               {isColumnVisible("diskUsage") && (
                 <Td dataLabel="Disk usage" modifier="fitContent">
                   {formatMetric(vm.utilization_disk)}
-                </Td>
-              )}
-              {isColumnVisible("ramUsage") && (
-                <Td dataLabel="RAM usage" modifier="fitContent">
-                  {formatMetric(vm.utilization_mem_p95)}
                 </Td>
               )}
               {isColumnVisible("datacenter") && (

--- a/apps/agent-ui/src/pages/Report/components/vmTableShared.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmTableShared.ts
@@ -8,9 +8,9 @@ export type ColumnKey =
   | "groups"
   | "vCenterState"
   | "id"
-  | "cpuUsage"
+  | "maxCPU"
+  | "maxRAM"
   | "diskUsage"
-  | "ramUsage"
   | "datacenter"
   | "cluster"
   | "diskSize"
@@ -41,9 +41,9 @@ export const Columns: Record<ColumnKey, string> = {
   vCenterState: "Status",
   migratable: "Migration Readiness",
   id: "ID",
-  cpuUsage: "CPU usage",
+  maxCPU: "Max CPU",
+  maxRAM: "Max RAM",
   diskUsage: "Disk usage",
-  ramUsage: "RAM usage",
   datacenter: "Data center",
   cluster: "Cluster",
   diskSize: "Disk size",
@@ -65,7 +65,7 @@ export const COMPACT_VISIBLE_COLUMNS: ColumnKey[] = [
 ];
 
 export const VISIBLE_COLUMNS_KEY = "vmTable.visibleColumns";
-export const VISIBLE_COLUMNS_VERSION = 5;
+export const VISIBLE_COLUMNS_VERSION = 6;
 
 export const isSortableColumn = (key: ColumnKey): key is SortableColumn =>
   (BACKEND_SORTABLE_COLUMNS as readonly ColumnKey[]).includes(key) ||
@@ -76,6 +76,16 @@ export const isBackendSortableColumn = (
 ): key is BackendSortableColumn =>
   key !== null &&
   (BACKEND_SORTABLE_COLUMNS as readonly ColumnKey[]).includes(key);
+
+export const getColumnModifier = (key: ColumnKey) => {
+  if (key === "issues" || key === "migratable") {
+    return "fitContent";
+  }
+  if (key === "labels") {
+    return "wrap";
+  }
+  return "nowrap";
+};
 
 export const statusLabels: Record<string, string> = {
   poweredOn: "Powered on",

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,7 +564,7 @@ __metadata:
   dependencies:
     "@emotion/css": "npm:^11.13.0"
     "@migration-planner-ui/ioc": "workspace:*"
-    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-a3d6bdc8bce2"
+    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-f90a4cad59fa"
     "@patternfly/react-charts": "npm:^8.0.0"
     "@patternfly/react-core": "npm:^6.4.3"
     "@patternfly/react-icons": "npm:^6.4.0"
@@ -607,10 +607,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openshift-migration-advisor/agent-sdk@npm:0.12.0-a3d6bdc8bce2":
-  version: 0.12.0-a3d6bdc8bce2
-  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-a3d6bdc8bce2"
-  checksum: 10c0/20145f368a340d3a1a20dc5dbe65270e30d1d56246575795e90f74b00ed2c316e042bcca86a572197a8c3eb72aa9bf3a0065010ad5635b763999bd77a1570ad9
+"@openshift-migration-advisor/agent-sdk@npm:0.12.0-f90a4cad59fa":
+  version: 0.12.0-f90a4cad59fa
+  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-f90a4cad59fa"
+  checksum: 10c0/127ceeb5c58c237d2eab2e6b2699a5ca164b9ca92f70749758a29dc4c577eb812e45f35598d47618e0c4ea30783af7a39c2354730cde4ad9ddd7e97dd71b9c5f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* remove custom column space on VMs list table.
* replace CPU usage by max CPU
* replace RAM usage by max RAM
* reorder max CPU and RAM together then disk usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VM table now displays maximum CPU and RAM metrics instead of usage metrics for improved resource visibility.

* **Style**
  * Enhanced table column layout and formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->