### PR TITLE
fix: ECOPROJECT-4603 | cancelling one deep inspection stops all inspections

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -109,7 +109,7 @@ export const VMTable: React.FC<VMTableProps> = ({
         onEditLabels={onEditLabels}
         onAddToGroup={onAddToGroup}
         onRemoveFromGroup={onRemoveFromGroup}
-        setIsCancelConfirmOpen={logic.setIsCancelConfirmOpen}
+        openCancelInspectionConfirm={logic.openCancelInspectionConfirm}
       />
 
       <VMTableModals

--- a/apps/agent-ui/src/pages/Report/components/VMTableGrid.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableGrid.tsx
@@ -40,7 +40,7 @@ export interface VMTableGridProps {
   onEditLabels?: (vmIds: string[]) => void;
   onAddToGroup?: (vmIds: string[]) => void;
   onRemoveFromGroup?: (vmIds: string[]) => void;
-  setIsCancelConfirmOpen: (open: boolean) => void;
+  openCancelInspectionConfirm: (vmId: string) => void;
 }
 
 export const VMTableGrid: React.FC<VMTableGridProps> = ({
@@ -58,7 +58,7 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
   onEditLabels,
   onAddToGroup,
   onRemoveFromGroup,
-  setIsCancelConfirmOpen,
+  openCancelInspectionConfirm,
 }) => {
   const {
     columns,
@@ -348,7 +348,7 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
                           return (
                             <DropdownItem
                               key="cancel-vm-inspection"
-                              onClick={() => setIsCancelConfirmOpen(true)}
+                              onClick={() => openCancelInspectionConfirm(vm.id)}
                             >
                               Cancel deep inspection
                             </DropdownItem>

--- a/apps/agent-ui/src/pages/Report/components/VMTableModals.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableModals.tsx
@@ -11,7 +11,7 @@ import type { VMTableLogic } from "./vmTableTypes";
 
 export interface VMTableModalsProps {
   logic: VMTableLogic;
-  onCancelInspection?: () => void;
+  onCancelInspection?: (vmId: string) => void;
   onExcludeFromReports?: (vmIds: string[]) => Promise<void>;
   onIncludeInReports?: (vmIds: string[]) => Promise<void>;
   onSelectionChange?: (selected: Set<string>) => void;
@@ -25,8 +25,8 @@ export const VMTableModals: React.FC<VMTableModalsProps> = ({
   onSelectionChange,
 }) => {
   const {
-    isCancelConfirmOpen,
-    setIsCancelConfirmOpen,
+    cancelInspectionVmId,
+    closeCancelInspectionConfirm,
     isExcludeModalOpen,
     setIsExcludeModalOpen,
     isExcludeLoading,
@@ -43,8 +43,8 @@ export const VMTableModals: React.FC<VMTableModalsProps> = ({
   return (
     <>
       <Modal
-        isOpen={isCancelConfirmOpen}
-        onClose={() => setIsCancelConfirmOpen(false)}
+        isOpen={cancelInspectionVmId !== null}
+        onClose={closeCancelInspectionConfirm}
         aria-labelledby="cancel-inspection-title"
         aria-describedby="cancel-inspection-body"
         variant="small"
@@ -55,19 +55,36 @@ export const VMTableModals: React.FC<VMTableModalsProps> = ({
           labelId="cancel-inspection-title"
         />
         <ModalBody id="cancel-inspection-body">
-          <Content component="p">Are you sure you want to proceed?</Content>
+          <Content component="p">
+            {(() => {
+              const vmName = cancelInspectionVmId
+                ? vmById.get(cancelInspectionVmId)?.name
+                : undefined;
+              if (vmName) {
+                return (
+                  <>
+                    Are you sure you want to cancel deep inspection for{" "}
+                    <strong>{vmName}</strong>?
+                  </>
+                );
+              }
+              return <>Are you sure you want to proceed?</>;
+            })()}
+          </Content>
         </ModalBody>
         <ModalFooter>
           <Button
             variant="danger"
             onClick={() => {
-              onCancelInspection?.();
-              setIsCancelConfirmOpen(false);
+              if (cancelInspectionVmId) {
+                onCancelInspection?.(cancelInspectionVmId);
+              }
+              closeCancelInspectionConfirm();
             }}
           >
             Confirm
           </Button>
-          <Button variant="link" onClick={() => setIsCancelConfirmOpen(false)}>
+          <Button variant="link" onClick={closeCancelInspectionConfirm}>
             Cancel
           </Button>
         </ModalFooter>

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -406,17 +406,18 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     }
   }, []);
 
-  const handleCancelInspection = useCallback(async () => {
-    if (!agentApi) return;
-    try {
-      await agentApi.stopInspection();
-      stopPolling();
-      setInspectionActive(false);
-      onRefreshVMs?.();
-    } catch (err) {
-      console.error("Error canceling inspection:", err);
-    }
-  }, [agentApi, onRefreshVMs, stopPolling]);
+  const handleCancelInspection = useCallback(
+    async (vmId: string) => {
+      if (!agentApi) return;
+      try {
+        await agentApi.removeVMFromInspection({ id: vmId });
+        onRefreshVMs?.();
+      } catch (err) {
+        console.error("Error canceling inspection:", err);
+      }
+    },
+    [agentApi, onRefreshVMs],
+  );
 
   const handleExcludeFromReports = useCallback(
     async (vmIds: string[]) => {

--- a/apps/agent-ui/src/pages/Report/components/useVMTableLogic.ts
+++ b/apps/agent-ui/src/pages/Report/components/useVMTableLogic.ts
@@ -102,8 +102,16 @@ export function useVMTableLogic({
   const [isConcernSelectOpen, setIsConcernSelectOpen] = useState(false);
   const [isVmLabelSelectOpen, setIsVmLabelSelectOpen] = useState(false);
 
-  // Cancel deep inspection confirmation
-  const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
+  // Cancel deep inspection confirmation (vm id when open, null when closed)
+  const [cancelInspectionVmId, setCancelInspectionVmId] = useState<
+    string | null
+  >(null);
+  const openCancelInspectionConfirm = useCallback((vmId: string) => {
+    setCancelInspectionVmId(vmId);
+  }, []);
+  const closeCancelInspectionConfirm = useCallback(() => {
+    setCancelInspectionVmId(null);
+  }, []);
 
   // Bulk actions menu
   const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
@@ -756,8 +764,9 @@ export function useVMTableLogic({
     setIsConcernSelectOpen,
     isVmLabelSelectOpen,
     setIsVmLabelSelectOpen,
-    isCancelConfirmOpen,
-    setIsCancelConfirmOpen,
+    cancelInspectionVmId,
+    openCancelInspectionConfirm,
+    closeCancelInspectionConfirm,
     isActionsMenuOpen,
     setIsActionsMenuOpen,
     isExcludeModalOpen,

--- a/apps/agent-ui/src/pages/Report/components/vmTableTypes.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmTableTypes.ts
@@ -40,7 +40,7 @@ export interface VMTableProps {
   onShowExcludedVMsChange?: (show: boolean) => void;
   hasInspectionResults?: boolean;
   inspectionActive?: boolean;
-  onCancelInspection?: () => void;
+  onCancelInspection?: (vmId: string) => void;
   onResetInspection?: () => void;
   variant?: VMTableVariant;
   showGroupsColumn?: boolean;


### PR DESCRIPTION
- The row-level “Cancel deep inspection” action was calling the global inspector stop API.
- Now we're passing the vm id from the row action through the modal to the handler and calling removeVMFromInspection({id:vmId}) instead of stopInspection()

[recording - 2026-06-01T150307.888.webm](https://github.com/user-attachments/assets/c9914983-1c0e-48fd-b15e-241f75a3cff0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the cancel inspection feature to operate on individual virtual machines rather than globally
  * Updated the confirmation dialog to clearly indicate which virtual machine will be affected when canceling an inspection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->