### PR TITLE
fix: solving npm security issues

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,8 @@
 enableGlobalCache: false
 
+# Reject npm package versions published less than 7 days ago (supply-chain cooldown).
+npmMinimalAgeGate: 10080
+
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
For migration-planner-ui we should set npmMinimalAgeGate: 10080 in .yarnrc.yml, not only min-release-age=7 in .npmrc.


Added both configs:

- .yarnrc.yml — primary protection for our workflow:
`npmMinimalAgeGate: 10080`

- .npmrc (repo root) — for direct npm usage (requires npm CLI 11.10+):
`min-release-age=7`
