### PR TITLE
fix: ECOPROJECT-4741 | VM's label filter should reflect OR relationship

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/vmFilters.test.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmFilters.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from "vitest";
 import { filtersToByExpression } from "./vmFilters";
 
+describe("filtersToByExpression vmLabels", () => {
+  it("uses a single contains check for one label", () => {
+    expect(filtersToByExpression({ vmLabels: ["prod"] })).toBe(
+      "(labels contains 'prod')",
+    );
+  });
+
+  it("uses OR when multiple labels are selected", () => {
+    expect(filtersToByExpression({ vmLabels: ["prod", "tier-1"] })).toBe(
+      "(labels contains 'prod' or labels contains 'tier-1')",
+    );
+  });
+
+  it("escapes single quotes in label values", () => {
+    expect(filtersToByExpression({ vmLabels: ["it's", "ok"] })).toBe(
+      "(labels contains 'it\\'s' or labels contains 'ok')",
+    );
+  });
+});
+
 describe("filtersToByExpression showExcludedVMs", () => {
   it("hides excluded VMs when the toggle is off", () => {
     expect(filtersToByExpression({ showExcludedVMs: false })).toBe(

--- a/apps/agent-ui/src/pages/Report/components/vmFilters.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmFilters.ts
@@ -135,10 +135,14 @@ export function filtersToByExpression(filters: VMFilters): string | undefined {
     }
   }
 
-  // VM user-defined labels (array field; use contains; multiple = AND)
+  // VM user-defined labels (array field; use contains; multiple = OR)
   if (filters.vmLabels && filters.vmLabels.length > 0) {
-    for (const label of filters.vmLabels) {
-      conditions.push(`labels contains '${escapeFilterValue(label)}'`);
+    if (filters.vmLabels?.length) {
+      const condition = filters.vmLabels
+        .map((label) => `labels contains '${escapeFilterValue(label)}'`)
+        .join(" or ");
+
+      conditions.push(`(${condition})`);
     }
   }
 


### PR DESCRIPTION
[recording - 2026-06-03T102951.547.webm](https://github.com/user-attachments/assets/23aa5d4f-4117-4db1-a9f0-4a761d7b33e8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified VM label filtering to match any selected label instead of requiring all labels.

* **Tests**
  * Added test coverage for VM label filtering logic, including single-label and multi-label OR combinations, and special character escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->