### PR TITLE
ECOPROJECT-4739 | fix: change filters in 'Create new group' modal

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/VMTableFilterBar.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableFilterBar.tsx
@@ -26,6 +26,7 @@ import {
   type ColumnKey,
   Columns,
   diskSizeRanges,
+  FILTER_DROPDOWN_MAX_HEIGHT,
   filterStyles,
   MANDATORY_COLUMNS,
   memorySizeRanges,
@@ -110,6 +111,15 @@ export const VMTableFilterBar: React.FC<VMTableFilterBarProps> = ({
   } = logic;
 
   const { showManageColumns } = variantUI;
+  const isCompactTable = !showManageColumns;
+
+  const handleFilterDropdownOpenChange = (open: boolean) => {
+    if (!open && (isConcernSelectOpen || isVmLabelSelectOpen)) {
+      return;
+    }
+    setIsFilterModalOpen(open);
+  };
+
   const filterDropdownContentRef = useRef<HTMLDivElement>(null);
   const nestedSelectPopperProps = {
     appendTo: () => filterDropdownContentRef.current ?? document.body,
@@ -231,7 +241,9 @@ export const VMTableFilterBar: React.FC<VMTableFilterBarProps> = ({
         <ToolbarItem>
           <Dropdown
             isOpen={isFilterModalOpen}
-            onOpenChange={setIsFilterModalOpen}
+            onOpenChange={handleFilterDropdownOpenChange}
+            isScrollable
+            maxMenuHeight={FILTER_DROPDOWN_MAX_HEIGHT}
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
               <MenuToggle
                 ref={toggleRef}
@@ -244,13 +256,23 @@ export const VMTableFilterBar: React.FC<VMTableFilterBarProps> = ({
             )}
             popperProps={{
               maxWidth: "95vw",
+              appendTo: () => document.body,
             }}
           >
             <div
-              ref={filterDropdownContentRef}
-              className={filterStyles.dropdownContent}
+              className={
+                isCompactTable
+                  ? filterStyles.dropdownContentCompact
+                  : filterStyles.dropdownContent
+              }
             >
-              <div className={filterStyles.filterGrid}>
+              <div
+                className={
+                  isCompactTable
+                    ? filterStyles.filtersContentCompact
+                    : filterStyles.filtersContent
+                }
+              >
                 {/* Issue categories column */}
                 <div>
                   <h3 className={filterStyles.columnTitle}>

--- a/apps/agent-ui/src/pages/Report/components/vmTableShared.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmTableShared.ts
@@ -142,16 +142,27 @@ export interface AppliedFilter {
   key: string;
 }
 
+/** Keeps the filters panel scrollable inside modals and short viewports. */
+export const FILTER_DROPDOWN_MAX_HEIGHT = "min(70vh, calc(100vh - 12rem))";
+
 export const filterStyles = {
   dropdownContent: css`
     padding: 24px;
-    width: 1400px;
     max-width: 95vw;
-    overflow: visible;
+    width: fit-content;
   `,
-  filterGrid: css`
+  dropdownContentCompact: css`
+    padding: 16px;
+    max-width: 95vw;
+    width: fit-content;
+  `,
+  filtersContent: css`
     display: grid;
     grid-template-columns: repeat(8, 1fr);
+  `,
+  filtersContentCompact: css`
+    display: flex;
+    flex-direction: column;
     gap: 24px;
   `,
   concernsColumn: css`
@@ -160,7 +171,6 @@ export const filterStyles = {
   `,
   concernSelect: css`
     width: 100%;
-    margin-top: 8px;
   `,
   columnTitle: css`
     font-size: 13px;


### PR DESCRIPTION
<img width="1186" height="883" alt="image" src="https://github.com/user-attachments/assets/5deb94f1-4abf-4200-9a4f-980624bc6c20" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compact filter layout option for narrower displays to improve form fitting and readability.

* **Style**
  * Improved filter dropdown sizing and layout for better visual fit and usability across viewports.

* **Bug Fixes**
  * Dropdowns now constrain height and allow scrolling; opening filter dropdowns no longer inadvertently closes when interacting with nested select controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->