### PR TITLE
ECOPROJECT-4752 | fix: clicking a slice or legend in report charts opens the Virtual Machines tab with the matching filter

### DIFF
--- a/apps/agent-ui/src/pages/Report/GroupDetailPage.tsx
+++ b/apps/agent-ui/src/pages/Report/GroupDetailPage.tsx
@@ -45,8 +45,10 @@ import { EditGroupNameModal } from "./components/EditGroupNameModal";
 import { combineFilterExpressions } from "./components/groupFilters";
 import {
   filtersToByExpression,
+  filtersToSearchParams,
   hasActiveFilters,
   searchParamsToFilters,
+  type VMFilters,
 } from "./components/vmFilters";
 import { Header } from "./Header";
 import {
@@ -112,6 +114,17 @@ export const GroupDetailPage: React.FC = () => {
 
   const [activeTab, setActiveTab] = useState<string | number>(() =>
     resolveReportTab(searchParams, hasActiveFilters(initialVMFilters)),
+  );
+
+  const handleNavigateToVMFilters = useCallback(
+    (filters: VMFilters) => {
+      setActiveTab(REPORT_TAB.vms);
+      setVmsPage(1);
+      const newParams = filtersToSearchParams(filters);
+      newParams.set("tab", "vms");
+      setSearchParams(newParams, { replace: true });
+    },
+    [setSearchParams],
   );
 
   const groupFilter = group?.filter;
@@ -423,6 +436,13 @@ export const GroupDetailPage: React.FC = () => {
     setVmsPage(1);
   };
 
+  const handleConcernClick = useCallback(
+    (concernLabel: string) => {
+      handleNavigateToVMFilters({ concernLabels: [concernLabel] });
+    },
+    [handleNavigateToVMFilters],
+  );
+
   const handleClusterSelect = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
     value: string | number | undefined,
@@ -627,6 +647,8 @@ export const GroupDetailPage: React.FC = () => {
                       isAggregateView={clusterView.isAggregateView}
                       clusterFound={clusterView.clusterFound}
                       scopedFilterExpression={group.filter}
+                      onConcernClick={handleConcernClick}
+                      onNavigateToVMFilters={handleNavigateToVMFilters}
                     />
                   </div>
                 ) : (

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -44,8 +44,10 @@ import {
 import { VMUtilizationMetrics } from "./components/VMUtilizationMetrics";
 import {
   filtersToByExpression,
+  filtersToSearchParams,
   hasActiveFilters,
   searchParamsToFilters,
+  type VMFilters,
 } from "./components/vmFilters";
 import { Header } from "./Header";
 import {
@@ -118,6 +120,17 @@ export const ReportContainer: React.FC = () => {
   const initialVMFilters = useMemo(
     () => searchParamsToFilters(searchParams),
     [searchParams],
+  );
+
+  const handleNavigateToVMFilters = useCallback(
+    (filters: VMFilters) => {
+      setActiveTab(1);
+      setVmsPage(1);
+      const newParams = filtersToSearchParams(filters);
+      newParams.set("tab", "vms");
+      setSearchParams(newParams, { replace: true });
+    },
+    [setSearchParams],
   );
 
   // Determine initial tab based on URL params (only on mount)
@@ -678,6 +691,7 @@ export const ReportContainer: React.FC = () => {
                     isAggregateView={clusterView.isAggregateView}
                     clusterFound={clusterView.clusterFound}
                     onConcernClick={handleConcernClick}
+                    onNavigateToVMFilters={handleNavigateToVMFilters}
                   />
                 ) : (
                   <Content component="p">

--- a/apps/agent-ui/src/pages/Report/components/ClustersOverview.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ClustersOverview.tsx
@@ -15,11 +15,9 @@ import {
 import { DatabaseIcon } from "@patternfly/react-icons";
 import type React from "react";
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { dashboardStyles } from "./dashboardStyles";
 import MigrationDonutChart from "./MigrationDonutChart";
-import { createVMFilterURL } from "./vmNavigation";
 
 interface ClustersOverviewProps {
   clustersPerDatacenter: number[];
@@ -151,7 +149,6 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
   isExportMode = false,
   clusters,
 }) => {
-  const navigate = useNavigate();
   const [viewMode, setViewMode] = useState<ViewMode>("vmByCluster");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -228,12 +225,8 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
       const rest = ranked.slice(TOP_N);
       const restSum = rest.reduce((acc, r) => acc + r.count, 0);
 
-      // Map display names to actual cluster names
-      const indexToName = new Map<string, string>();
-
       const slices = top.map((item, i) => {
         const displayName = `Cluster ${i + 1}`;
-        indexToName.set(displayName, item.name);
         return {
           name: displayName,
           count: item.count,
@@ -316,11 +309,6 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
       setViewMode(value);
     }
     setIsDropdownOpen(false);
-  };
-
-  const handleTitleClick = () => {
-    // Navigate to all VMs without filters
-    navigate(createVMFilterURL({}));
   };
 
   return (
@@ -442,11 +430,6 @@ export const ClustersOverview: React.FC<ClustersOverviewProps> = ({
             itemsPerRow={chartData.length}
             tooltipLabelFormatter={({ datum, percent }) =>
               `${datum.countDisplay}\n${percent.toFixed(1)}%`
-            }
-            onTitleClick={
-              !isExportMode && viewMode === "vmByCluster"
-                ? handleTitleClick
-                : undefined
             }
           />
         )}

--- a/apps/agent-ui/src/pages/Report/components/CpuAndMemoryOverview.tsx
+++ b/apps/agent-ui/src/pages/Report/components/CpuAndMemoryOverview.tsx
@@ -14,10 +14,10 @@ import {
 import { DataProcessorIcon } from "@patternfly/react-icons";
 import type React from "react";
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { dashboardStyles } from "./dashboardStyles";
 import MigrationDonutChart from "./MigrationDonutChart";
-import { createVMFilterURL } from "./vmNavigation";
+import { type NavigateToVMFilters, useChartDrillDown } from "./vmNavigation";
+import { parseMemoryTierLabelToRange } from "./vmTableShared";
 
 interface CpuAndMemoryOverviewProps {
   cpuTierDistribution?: Record<string, number>;
@@ -25,6 +25,7 @@ interface CpuAndMemoryOverviewProps {
   memoryTotalGB?: number;
   cpuTotalCores?: number;
   isExportMode?: boolean;
+  onNavigateToVMFilters?: NavigateToVMFilters;
 }
 
 type ViewMode = "memoryTiers" | "vcpuTiers";
@@ -51,8 +52,9 @@ export const CpuAndMemoryOverview: React.FC<CpuAndMemoryOverviewProps> = ({
   memoryTotalGB,
   cpuTotalCores,
   isExportMode = false,
+  onNavigateToVMFilters,
 }) => {
-  const navigate = useNavigate();
+  const navigateToVMs = useChartDrillDown(onNavigateToVMFilters);
   const [viewMode, setViewMode] = useState<ViewMode>("memoryTiers");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -69,6 +71,7 @@ export const CpuAndMemoryOverview: React.FC<CpuAndMemoryOverviewProps> = ({
         count,
         countDisplay: `${count} VMs`,
         legendCategory: tier,
+        memoryRange: parseMemoryTierLabelToRange(tier),
       }));
   }, [memoryTierDistribution]);
 
@@ -106,50 +109,25 @@ export const CpuAndMemoryOverview: React.FC<CpuAndMemoryOverviewProps> = ({
   const parseMemoryTierToFilter = (
     tier: string,
   ): { min: number; max?: number } | null => {
-    const MB_IN_GB = 1024;
-    const normalized = tier.trim();
-
-    // Memory range mappings matching VMTable
-    const memoryRangeMappings: Record<
-      string,
-      { min: number; max: number | undefined }
-    > = {
-      "0-4": { min: 0, max: 4 * MB_IN_GB },
-      "0-4 GB": { min: 0, max: 4 * MB_IN_GB },
-      "5-16": { min: 4 * MB_IN_GB + 1, max: 16 * MB_IN_GB },
-      "5-16 GB": { min: 4 * MB_IN_GB + 1, max: 16 * MB_IN_GB },
-      "17-32": { min: 16 * MB_IN_GB + 1, max: 32 * MB_IN_GB },
-      "17-32 GB": { min: 16 * MB_IN_GB + 1, max: 32 * MB_IN_GB },
-      "33-64": { min: 32 * MB_IN_GB + 1, max: 64 * MB_IN_GB },
-      "33-64 GB": { min: 32 * MB_IN_GB + 1, max: 64 * MB_IN_GB },
-      "65-128": { min: 64 * MB_IN_GB + 1, max: 128 * MB_IN_GB },
-      "65-128 GB": { min: 64 * MB_IN_GB + 1, max: 128 * MB_IN_GB },
-      "129-256": { min: 128 * MB_IN_GB + 1, max: 256 * MB_IN_GB },
-      "129-256 GB": { min: 128 * MB_IN_GB + 1, max: 256 * MB_IN_GB },
-      "256+": { min: 256 * MB_IN_GB + 1, max: undefined },
-      "256+ GB": { min: 256 * MB_IN_GB + 1, max: undefined },
-    };
-
-    if (normalized in memoryRangeMappings) {
-      return memoryRangeMappings[normalized];
-    }
-
-    return null;
+    return parseMemoryTierLabelToRange(tier) ?? null;
   };
 
   const handleMemoryTierClick = (item: {
     name: string;
     legendCategory: string;
+    memoryRange?: { min: number; max?: number };
   }) => {
-    const memoryRange = parseMemoryTierToFilter(item.legendCategory);
+    const memoryRange =
+      item.memoryRange ??
+      parseMemoryTierToFilter(item.legendCategory) ??
+      parseMemoryTierToFilter(item.name);
     if (memoryRange) {
-      navigate(createVMFilterURL({ memoryRange }));
+      navigateToVMs({ memoryRange });
     }
   };
 
   const handleTitleClick = () => {
-    // Navigate to all VMs without filters
-    navigate(createVMFilterURL({}));
+    navigateToVMs({});
   };
 
   return (

--- a/apps/agent-ui/src/pages/Report/components/Dashboard.tsx
+++ b/apps/agent-ui/src/pages/Report/components/Dashboard.tsx
@@ -21,6 +21,7 @@ import { NetworkOverview } from "./NetworkOverview";
 import { OSDistribution } from "./OSDistribution";
 import { StorageOverview } from "./StorageOverview";
 import { VMMigrationStatus } from "./VMMigrationStatus";
+import type { NavigateToVMFilters } from "./vmNavigation";
 import { WarningsTable } from "./WarningsTable";
 
 interface DashboardProps {
@@ -34,6 +35,7 @@ interface DashboardProps {
   clusterFound?: boolean;
   onConcernClick?: (concernLabel: string) => void;
   scopedFilterExpression?: string;
+  onNavigateToVMFilters?: NavigateToVMFilters;
 }
 
 export const Dashboard: React.FC<DashboardProps> = ({
@@ -47,6 +49,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
   clusterFound = true,
   onConcernClick,
   scopedFilterExpression,
+  onNavigateToVMFilters,
 }) => {
   // Transform osInfo to include both count and supported fields
   const osData = vms.osInfo
@@ -113,6 +116,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 }}
                 isExportMode={isExportMode}
                 scopedFilterExpression={scopedFilterExpression}
+                onNavigateToVMFilters={onNavigateToVMFilters}
               />
             </GalleryItem>
             <GalleryItem>
@@ -130,6 +134,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 memoryTierDistribution={vms.distributionByMemoryTier}
                 memoryTotalGB={ramGB?.total}
                 cpuTotalCores={cpuCores?.total}
+                onNavigateToVMFilters={onNavigateToVMFilters}
               />
             </GalleryItem>
             <GalleryItem>
@@ -140,6 +145,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 totalWithSharedDisks={vms.totalWithSharedDisks ?? 0}
                 isExportMode={isExportMode}
                 exportAllViews={isExportMode}
+                onNavigateToVMFilters={onNavigateToVMFilters}
               />
             </GalleryItem>
           </Gallery>

--- a/apps/agent-ui/src/pages/Report/components/MigrationDonutChart.tsx
+++ b/apps/agent-ui/src/pages/Report/components/MigrationDonutChart.tsx
@@ -13,6 +13,10 @@ interface OSData {
   count: number;
   legendCategory: string;
   countDisplay?: string;
+  diskRange?: { min: number; max?: number };
+  memoryRange?: { min: number; max?: number };
+  clusterNames?: string[];
+  networkNames?: string[];
 }
 
 interface MigrationDonutChartProps {
@@ -167,16 +171,21 @@ const MigrationDonutChart: React.FC<MigrationDonutChartProps> = ({
 
   const handleClick = useCallback(
     // biome-ignore lint/suspicious/noExplicitAny: Victory chart types are not well-typed
-    (event: any) => {
-      if (!onItemClick || !event?.datum) return;
+    (props: any) => {
+      if (!onItemClick) return;
 
-      // Find the original data item - first try exact name match
-      let clickedItem = data.find((item) => item.name === event.datum.x);
+      const datum = props?.datum;
+      if (!datum) return;
 
-      // If no exact name match, fall back to legendCategory match
+      let clickedItem = data.find((item) => item.name === datum.x);
+
+      if (!clickedItem && typeof props.index === "number") {
+        clickedItem = data[props.index];
+      }
+
       if (!clickedItem) {
         clickedItem = data.find(
-          (item) => item.legendCategory === event.datum.legendCategory,
+          (item) => item.legendCategory === datum.legendCategory,
         );
       }
 

--- a/apps/agent-ui/src/pages/Report/components/NetworkOverview.tsx
+++ b/apps/agent-ui/src/pages/Report/components/NetworkOverview.tsx
@@ -17,11 +17,9 @@ import {
 import { TopologyIcon } from "@patternfly/react-icons";
 import type React from "react";
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { dashboardStyles } from "./dashboardStyles";
 
 import MigrationDonutChart from "./MigrationDonutChart";
-import { createVMFilterURL } from "./vmNavigation";
 
 // Reuse an extended palette similar to ClustersOverview to provide stable colors
 const colorPalette = [
@@ -59,7 +57,6 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
   distributionByNicCount,
   isExportMode = false,
 }) => {
-  const navigate = useNavigate();
   const [viewMode, setViewMode] = useState<ViewMode>("networkDistribution");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -252,11 +249,6 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
     setIsDropdownOpen(false);
   };
 
-  const handleTitleClick = () => {
-    // Navigate to all VMs without filters
-    navigate(createVMFilterURL({}));
-  };
-
   return (
     <Card
       className={
@@ -332,7 +324,6 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
             tooltipLabelFormatter={({ datum, percent }) =>
               `${datum.countDisplay}\n${percent.toFixed(1)}%\nVLAN: ${legendVlanMap[datum.legendCategory] ?? "-"}`
             }
-            onTitleClick={!isExportMode ? handleTitleClick : undefined}
           />
         )}
         {viewMode === "nicCount" && (
@@ -351,7 +342,6 @@ export const NetworkOverview: React.FC<NetworkOverviewProps> = ({
             tooltipLabelFormatter={({ datum, percent }) =>
               `${datum.countDisplay}\n${percent.toFixed(1)}%`
             }
-            onTitleClick={!isExportMode ? handleTitleClick : undefined}
           />
         )}
       </CardBody>

--- a/apps/agent-ui/src/pages/Report/components/StorageOverview.tsx
+++ b/apps/agent-ui/src/pages/Report/components/StorageOverview.tsx
@@ -23,10 +23,10 @@ import chart_color_teal_300 from "@patternfly/react-tokens/dist/esm/chart_color_
 import chart_color_yellow_400 from "@patternfly/react-tokens/dist/esm/chart_color_yellow_400";
 import type React from "react";
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { dashboardStyles } from "./dashboardStyles";
 import MigrationDonutChart from "./MigrationDonutChart";
-import { createVMFilterURL } from "./vmNavigation";
+import { type NavigateToVMFilters, useChartDrillDown } from "./vmNavigation";
+import { parseDiskTierLabelToRange } from "./vmTableShared";
 
 interface DiskTierData {
   vmCount?: number;
@@ -40,6 +40,7 @@ interface StorageOverviewProps {
   totalWithSharedDisks?: number;
   isExportMode?: boolean;
   exportAllViews?: boolean;
+  onNavigateToVMFilters?: NavigateToVMFilters;
 }
 
 type ViewMode = "totalSize" | "vmCount" | "vmCountByDiskType" | "sharedDisks";
@@ -66,6 +67,7 @@ type TierChartDatum = {
   count: number;
   countDisplay: string;
   legendCategory: string;
+  diskRange?: { min: number; max?: number };
 };
 
 function buildTierChartData(
@@ -82,33 +84,38 @@ function buildTierChartData(
   if (!summary) return [];
 
   const getTierPrefix = (key: string): string | null => {
+    const normalizedKey = key.trim().toLowerCase();
     for (const prefix of Object.keys(tierConfig)) {
-      if (key.startsWith(prefix)) return prefix;
+      if (normalizedKey.startsWith(prefix.toLowerCase())) {
+        return prefix;
+      }
     }
     return null;
   };
 
   return Object.entries(summary)
-    .sort(([keyA], [keyB]) => {
-      const prefixA = getTierPrefix(keyA);
-      const prefixB = getTierPrefix(keyB);
-      const orderA = prefixA ? tierConfig[prefixA].order : 999;
-      const orderB = prefixB ? tierConfig[prefixB].order : 999;
-      return orderA - orderB;
-    })
     .map(([key, tier]) => {
       const prefix = getTierPrefix(key);
       const display = prefix
         ? tierConfig[prefix]
         : { label: key, legendCategory: key };
       const { count, countDisplay } = selector(tier);
+      const label = display.label;
       return {
-        name: display.label,
+        name: label,
         count,
         countDisplay,
         legendCategory: display.legendCategory,
+        diskRange:
+          parseDiskTierLabelToRange(key) ?? parseDiskTierLabelToRange(label),
+        sortOrder:
+          parseDiskTierLabelToRange(key)?.min ??
+          parseDiskTierLabelToRange(label)?.min ??
+          (prefix ? tierConfig[prefix].order : 999),
       };
-    });
+    })
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map(({ sortOrder: _sortOrder, ...datum }) => datum);
 }
 
 const COLOR_PALETTE = [
@@ -264,8 +271,9 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
   totalWithSharedDisks,
   isExportMode = false,
   exportAllViews = false,
+  onNavigateToVMFilters,
 }) => {
-  const navigate = useNavigate();
+  const navigateToVMs = useChartDrillDown(onNavigateToVMFilters);
   const [viewMode, setViewMode] = useState<ViewMode>("vmCount");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -407,39 +415,24 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
     setIsDropdownOpen(false);
   };
 
-  const parseDiskTierToFilter = (
-    tier: string,
-  ): { min: number; max?: number } | null => {
-    const MB_IN_TB = 1024 * 1024;
-    const normalized = tier.trim();
-
-    const diskRangeMappings: Record<
-      string,
-      { min: number; max: number | undefined }
-    > = {
-      "0-10 TB": { min: 0, max: 10 * MB_IN_TB },
-      "11-20 TB": { min: 10 * MB_IN_TB + 1, max: 20 * MB_IN_TB },
-      "21-50 TB": { min: 20 * MB_IN_TB + 1, max: 50 * MB_IN_TB },
-      "50+ TB": { min: 50 * MB_IN_TB + 1, max: undefined },
-      "> 50 TB": { min: 50 * MB_IN_TB + 1, max: undefined },
-    };
-
-    if (normalized in diskRangeMappings) {
-      return diskRangeMappings[normalized];
-    }
-
-    return null;
-  };
-
-  const handleDiskTierClick = (item: { name: string }) => {
-    const diskRange = parseDiskTierToFilter(item.name);
+  const handleDiskTierClick = (item: {
+    name: string;
+    legendCategory?: string;
+    diskRange?: { min: number; max?: number };
+  }) => {
+    const diskRange =
+      item.diskRange ??
+      parseDiskTierLabelToRange(item.name) ??
+      (item.legendCategory
+        ? parseDiskTierLabelToRange(item.legendCategory)
+        : undefined);
     if (diskRange) {
-      navigate(createVMFilterURL({ diskRange }));
+      navigateToVMs({ diskRange });
     }
   };
 
   const handleTitleClick = () => {
-    navigate(createVMFilterURL({}));
+    navigateToVMs({});
   };
 
   return (
@@ -560,7 +553,12 @@ export const StorageOverview: React.FC<StorageOverviewProps> = ({
               tooltipLabelFormatter={({ datum, percent }) =>
                 `${datum.x}: ${datum.countDisplay}\n${percent.toFixed(1)}%`
               }
-              onItemClick={!isExportMode ? handleDiskTierClick : undefined}
+              onItemClick={
+                !isExportMode &&
+                (viewMode === "vmCount" || viewMode === "totalSize")
+                  ? handleDiskTierClick
+                  : undefined
+              }
               onTitleClick={!isExportMode ? handleTitleClick : undefined}
             />
           )

--- a/apps/agent-ui/src/pages/Report/components/VMMigrationStatus.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMMigrationStatus.tsx
@@ -17,13 +17,12 @@ import {
 import { VirtualMachineIcon } from "@patternfly/react-icons";
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { Symbols } from "../../../main/Symbols";
 import { chartColorFailure, chartColorSuccess } from "./constants";
 import { dashboardStyles } from "./dashboardStyles";
 import { combineFilterExpressions } from "./groupFilters";
 import MigrationDonutChart from "./MigrationDonutChart";
-import { createVMFilterURL } from "./vmNavigation";
+import { type NavigateToVMFilters, useChartDrillDown } from "./vmNavigation";
 
 type ViewMode = "issuesVsNoIssues" | "issuesBreakdown";
 
@@ -34,6 +33,7 @@ interface VmMigrationStatusProps {
   };
   isExportMode?: boolean;
   scopedFilterExpression?: string;
+  onNavigateToVMFilters?: NavigateToVMFilters;
 }
 
 const categoryOrder = [
@@ -69,9 +69,10 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
   data,
   isExportMode = false,
   scopedFilterExpression,
+  onNavigateToVMFilters,
 }) => {
-  const navigate = useNavigate();
   const agentApi = useInjection<DefaultApiInterface>(Symbols.AgentApi);
+  const navigateToVMs = useChartDrillDown(onNavigateToVMFilters);
   const [viewMode, setViewMode] = useState<ViewMode>("issuesVsNoIssues");
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [issuesBreakdown, setIssuesBreakdown] = useState<{
@@ -285,15 +286,21 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
     if (viewMode === "issuesVsNoIssues") {
       const migrationReadiness =
         item.name === "Migratable" ? ["ready"] : ["not-ready"];
-      const url = createVMFilterURL({ migrationReadiness });
-      navigate(url);
+      navigateToVMs({ migrationReadiness });
     }
+  };
+
+  const handleBreakdownClick = (category: string) => {
+    if (isExportMode) return;
+    navigateToVMs({
+      migrationReadiness: ["not-ready"],
+      concernCategories: [category],
+    });
   };
 
   const handleTitleClick = () => {
     if (isExportMode) return;
-    const url = createVMFilterURL({});
-    navigate(url);
+    navigateToVMs({});
   };
 
   const totalVMs = data.migratable + data.nonMigratable;
@@ -371,7 +378,7 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
             legendLabelFormatter={({ x, countDisplay }) =>
               `${x} (${countDisplay})`
             }
-            onItemClick={handleItemClick}
+            onItemClick={!isExportMode ? handleItemClick : undefined}
             onTitleClick={!isExportMode ? handleTitleClick : undefined}
           />
         ) : isLoadingBreakdown ? (
@@ -441,16 +448,34 @@ export const VMMigrationStatus: React.FC<VmMigrationStatusProps> = ({
                           justifyContent: "center",
                         }}
                       >
-                        <div
-                          style={{
-                            width: "60px",
-                            height: `${finalHeightPercentage}%`,
-                            backgroundColor: barColor,
-                            transition: "height 0.3s ease",
-                            borderRadius: "4px 4px 0 0",
-                          }}
-                          title={`${item.name}: ${item.count} VMs`}
-                        />
+                        {!isExportMode ? (
+                          <button
+                            type="button"
+                            onClick={() => handleBreakdownClick(item.name)}
+                            title={`${item.name}: ${item.count} VMs`}
+                            style={{
+                              width: "60px",
+                              height: `${finalHeightPercentage}%`,
+                              backgroundColor: barColor,
+                              transition: "height 0.3s ease",
+                              borderRadius: "4px 4px 0 0",
+                              cursor: "pointer",
+                              border: "none",
+                              padding: 0,
+                            }}
+                          />
+                        ) : (
+                          <div
+                            style={{
+                              width: "60px",
+                              height: `${finalHeightPercentage}%`,
+                              backgroundColor: barColor,
+                              transition: "height 0.3s ease",
+                              borderRadius: "4px 4px 0 0",
+                            }}
+                            title={`${item.name}: ${item.count} VMs`}
+                          />
+                        )}
                       </FlexItem>
                       <FlexItem>
                         <Content

--- a/apps/agent-ui/src/pages/Report/components/vmFilters.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmFilters.ts
@@ -4,6 +4,7 @@ export interface VMFilters {
   statuses?: string[];
   clusters?: string[];
   datacenters?: string[];
+  networks?: string[];
   search?: string;
   diskRange?: { min: number; max?: number };
   memoryRange?: { min: number; max?: number };
@@ -69,6 +70,20 @@ export function filtersToByExpression(filters: VMFilters): string | undefined {
         .map((d) => `'${escapeFilterValue(d)}'`)
         .join(",");
       conditions.push(`datacenter in [${datacenterList}]`);
+    }
+  }
+
+  // Network filter
+  if (filters.networks && filters.networks.length > 0) {
+    if (filters.networks.length === 1) {
+      conditions.push(
+        `net.network = '${escapeFilterValue(filters.networks[0])}'`,
+      );
+    } else {
+      const networkList = filters.networks
+        .map((n) => `'${escapeFilterValue(n)}'`)
+        .join(",");
+      conditions.push(`net.network in [${networkList}]`);
     }
   }
 
@@ -195,11 +210,19 @@ export function filtersToSearchParams(filters: VMFilters): URLSearchParams {
   }
 
   if (filters.clusters && filters.clusters.length > 0) {
-    params.set("clusters", filters.clusters.join(","));
+    for (const cluster of filters.clusters) {
+      params.append("clusters", cluster);
+    }
   }
 
   if (filters.datacenters && filters.datacenters.length > 0) {
     params.set("datacenters", filters.datacenters.join(","));
+  }
+
+  if (filters.networks && filters.networks.length > 0) {
+    for (const network of filters.networks) {
+      params.append("networks", network);
+    }
   }
 
   if (filters.search) {
@@ -266,14 +289,19 @@ export function searchParamsToFilters(
     filters.statuses = statuses.split(",").filter(Boolean);
   }
 
-  const clusters = searchParams.get("clusters");
-  if (clusters) {
-    filters.clusters = clusters.split(",").filter(Boolean);
+  const clusters = searchParams.getAll("clusters");
+  if (clusters.length > 0) {
+    filters.clusters = clusters.filter(Boolean);
   }
 
   const datacenters = searchParams.get("datacenters");
   if (datacenters) {
     filters.datacenters = datacenters.split(",").filter(Boolean);
+  }
+
+  const networks = searchParams.getAll("networks");
+  if (networks.length > 0) {
+    filters.networks = networks.filter(Boolean);
   }
 
   const search = searchParams.get("search");
@@ -346,6 +374,7 @@ export function hasActiveFilters(filters: VMFilters): boolean {
     (filters.statuses && filters.statuses.length > 0) ||
     (filters.clusters && filters.clusters.length > 0) ||
     (filters.datacenters && filters.datacenters.length > 0) ||
+    (filters.networks && filters.networks.length > 0) ||
     (filters.migrationReadiness && filters.migrationReadiness.length > 0) ||
     (filters.vmLabels && filters.vmLabels.length > 0) ||
     (filters.concernLabels && filters.concernLabels.length > 0) ||

--- a/apps/agent-ui/src/pages/Report/components/vmNavigation.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmNavigation.ts
@@ -1,14 +1,38 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import { filtersToSearchParams, type VMFilters } from "./vmFilters";
+
+export const DEFAULT_VM_FILTER_BASE_PATH = "/report/vms-overview";
+
+export type NavigateToVMFilters = (filters: VMFilters) => void;
+
+/** Navigates to the VMs tab with filters, using the page callback when provided. */
+export function useChartDrillDown(
+  onNavigateToVMFilters?: NavigateToVMFilters,
+): (filters: VMFilters) => void {
+  const navigate = useNavigate();
+
+  return useCallback(
+    (filters: VMFilters) => {
+      if (onNavigateToVMFilters) {
+        onNavigateToVMFilters(filters);
+        return;
+      }
+      navigate(createVMFilterURL(filters));
+    },
+    [navigate, onNavigateToVMFilters],
+  );
+}
 
 /**
  * Creates a URL to navigate to the Virtual Machines tab with specific filters
  * @param filters - The filters to apply
- * @param basePath - The base path (defaults to "/report")
+ * @param basePath - The base path (defaults to "/report/vms-overview")
  * @returns A URL string with the filters encoded
  */
 export function createVMFilterURL(
   filters: VMFilters,
-  basePath = "/report",
+  basePath = DEFAULT_VM_FILTER_BASE_PATH,
 ): string {
   const params = filtersToSearchParams(filters);
   params.set("tab", "vms");

--- a/apps/agent-ui/src/pages/Report/components/vmTableFilterLogic.test.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmTableFilterLogic.test.ts
@@ -53,7 +53,7 @@ describe("vmTableFilterLogic", () => {
       },
       {
         category: "Disk size",
-        label: "11-20 TB",
+        label: "100-500GiB",
         key: "diskSize",
       },
     ]);

--- a/apps/agent-ui/src/pages/Report/components/vmTableShared.test.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmTableShared.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { diskSizeRanges, parseDiskTierLabelToRange } from "./vmTableShared";
+
+describe("diskSizeRanges", () => {
+  it("matches GiB/TiB tiers used by inventory summaries", () => {
+    for (const range of diskSizeRanges) {
+      expect(parseDiskTierLabelToRange(range.label)).toEqual({
+        min: range.min,
+        max: range.max,
+      });
+    }
+  });
+});
+
+describe("parseDiskTierLabelToRange", () => {
+  it("parses GiB disk tiers from inventory summaries", () => {
+    expect(parseDiskTierLabelToRange("0-100GiB")).toEqual({
+      min: 0,
+      max: 102400,
+    });
+    expect(parseDiskTierLabelToRange("100-500GiB")).toEqual({
+      min: 102400,
+      max: 512000,
+    });
+    expect(parseDiskTierLabelToRange("500GiB-1TiB")).toEqual({
+      min: 512000,
+      max: 1024 * 1024,
+    });
+    expect(parseDiskTierLabelToRange("1-2TiB")).toEqual({
+      min: 1024 * 1024,
+      max: 2 * 1024 * 1024,
+    });
+    expect(parseDiskTierLabelToRange("2-5TiB")).toEqual({
+      min: 2 * 1024 * 1024,
+      max: 5 * 1024 * 1024,
+    });
+  });
+
+  it("parses legacy TB migration tiers", () => {
+    expect(parseDiskTierLabelToRange("0-10 TB")).toEqual({
+      min: 0,
+      max: 10 * 1024 * 1024,
+    });
+    expect(parseDiskTierLabelToRange("50+ TB")).toEqual({
+      min: 50 * 1024 * 1024 + 1,
+      max: undefined,
+    });
+    expect(parseDiskTierLabelToRange("> 50 TB")).toEqual({
+      min: 50 * 1024 * 1024 + 1,
+      max: undefined,
+    });
+  });
+});

--- a/apps/agent-ui/src/pages/Report/components/vmTableShared.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmTableShared.ts
@@ -93,12 +93,102 @@ export const statusLabels: Record<string, string> = {
   suspended: "Suspended",
 };
 
+const MB_IN_GIB = 1024;
+const MB_IN_TIB = 1024 * 1024;
+
 export const diskSizeRanges = [
-  { label: "0-10 TB", min: 0, max: 10 * 1024 * 1024 },
-  { label: "11-20 TB", min: 10 * 1024 * 1024 + 1, max: 20 * 1024 * 1024 },
-  { label: "21-50 TB", min: 20 * 1024 * 1024 + 1, max: 50 * 1024 * 1024 },
-  { label: "50+ TB", min: 50 * 1024 * 1024 + 1, max: undefined },
+  { label: "0-100GiB", min: 0, max: 100 * MB_IN_GIB },
+  { label: "100-500GiB", min: 100 * MB_IN_GIB, max: 500 * MB_IN_GIB },
+  { label: "500GiB-1TiB", min: 500 * MB_IN_GIB, max: MB_IN_TIB },
+  { label: "1-2TiB", min: MB_IN_TIB, max: 2 * MB_IN_TIB },
+  { label: "2-5TiB", min: 2 * MB_IN_TIB, max: 5 * MB_IN_TIB },
 ];
+
+const legacyDiskSizeRanges = [
+  { label: "0-10 TB", min: 0, max: 10 * MB_IN_TIB },
+  { label: "11-20 TB", min: 10 * MB_IN_TIB + 1, max: 20 * MB_IN_TIB },
+  { label: "21-50 TB", min: 20 * MB_IN_TIB + 1, max: 50 * MB_IN_TIB },
+  { label: "50+ TB", min: 50 * MB_IN_TIB + 1, max: undefined },
+];
+
+function sizeValueToMB(value: string, unit: string): number {
+  const amount = Number.parseFloat(value);
+  if (!Number.isFinite(amount)) {
+    return Number.NaN;
+  }
+
+  switch (unit.toLowerCase()) {
+    case "gib":
+    case "gb":
+      return amount * MB_IN_GIB;
+    case "tib":
+    case "tb":
+      return amount * MB_IN_TIB;
+    case "mib":
+    case "mb":
+      return amount;
+    default:
+      return Number.NaN;
+  }
+}
+
+/** Parses inventory disk tier labels (GiB/TiB or legacy TB buckets) into MB ranges. */
+export function parseDiskTierLabelToRange(
+  label: string,
+): { min: number; max?: number } | undefined {
+  const normalized = label.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  const predefined =
+    diskSizeRanges.find((range) => range.label === normalized) ??
+    legacyDiskSizeRanges.find(
+      (range) =>
+        range.label === normalized ||
+        (normalized === "> 50 TB" && range.label === "50+ TB"),
+    );
+  if (predefined) {
+    return { min: predefined.min, max: predefined.max };
+  }
+
+  const mixedUnitRange =
+    /^(\d+(?:\.\d+)?)\s*(GiB|TiB|GB|TB|MIB|MB)\s*-\s*(\d+(?:\.\d+)?)\s*(GiB|TiB|GB|TB|MIB|MB)$/i.exec(
+      normalized,
+    );
+  if (mixedUnitRange) {
+    const min = sizeValueToMB(mixedUnitRange[1], mixedUnitRange[2]);
+    const max = sizeValueToMB(mixedUnitRange[3], mixedUnitRange[4]);
+    if (Number.isFinite(min) && Number.isFinite(max)) {
+      return { min: Math.floor(min), max: Math.floor(max) };
+    }
+  }
+
+  const singleUnitRange =
+    /^(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)\s*(GiB|TiB|GB|TB|MIB|MB)$/i.exec(
+      normalized,
+    );
+  if (singleUnitRange) {
+    const min = sizeValueToMB(singleUnitRange[1], singleUnitRange[3]);
+    const max = sizeValueToMB(singleUnitRange[2], singleUnitRange[3]);
+    if (Number.isFinite(min) && Number.isFinite(max)) {
+      return { min: Math.floor(min), max: Math.floor(max) };
+    }
+  }
+
+  const openEndedRange =
+    /^(\d+(?:\.\d+)?)\s*(GiB|TiB|GB|TB|MIB|MB)?\s*\+$/i.exec(normalized);
+  if (openEndedRange) {
+    const unit = openEndedRange[2] || "TB";
+    const min = sizeValueToMB(openEndedRange[1], unit);
+    if (Number.isFinite(min)) {
+      const minMB = Math.floor(min);
+      return { min: minMB > 0 ? minMB + 1 : minMB, max: undefined };
+    }
+  }
+
+  return undefined;
+}
 
 export const memorySizeRanges = [
   { label: "0-4 GB", min: 0, max: 4 * 1024 },
@@ -109,6 +199,55 @@ export const memorySizeRanges = [
   { label: "129-256 GB", min: 128 * 1024 + 1, max: 256 * 1024 },
   { label: "256+ GB", min: 256 * 1024 + 1, max: undefined },
 ];
+
+/** Parses inventory memory tier labels into MB ranges for VM filtering. */
+export function parseMemoryTierLabelToRange(
+  label: string,
+): { min: number; max?: number } | undefined {
+  const normalized = label.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  const labelVariants = [
+    normalized,
+    /gb$/i.test(normalized) ? normalized : `${normalized} GB`,
+    normalized.replace(/\s+GB$/i, ""),
+  ];
+
+  for (const variant of labelVariants) {
+    const range = memorySizeRanges.find((entry) => entry.label === variant);
+    if (range) {
+      return { min: range.min, max: range.max };
+    }
+  }
+
+  const openEnded = /^(\d+(?:\.\d+)?)\s*\+$/i.exec(
+    normalized.replace(/\s+GB$/i, ""),
+  );
+  if (openEnded) {
+    const minGb = Number.parseInt(openEnded[1], 10);
+    if (Number.isFinite(minGb)) {
+      return { min: minGb * 1024 + 1, max: undefined };
+    }
+  }
+
+  const bounded = /^(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)$/i.exec(
+    normalized.replace(/\s+GB$/i, ""),
+  );
+  if (bounded) {
+    const minGb = Number.parseInt(bounded[1], 10);
+    const maxGb = Number.parseInt(bounded[2], 10);
+    if (Number.isFinite(minGb) && Number.isFinite(maxGb)) {
+      return {
+        min: minGb * 1024,
+        max: maxGb * 1024,
+      };
+    }
+  }
+
+  return undefined;
+}
 
 const MB_IN_GB = 1024;
 const MB_IN_TB = 1024 * 1024;

--- a/apps/agent-ui/src/pages/Report/reportTabNavigation.ts
+++ b/apps/agent-ui/src/pages/Report/reportTabNavigation.ts
@@ -58,6 +58,7 @@ export function clearVmFilterParams(params: URLSearchParams): void {
   params.delete("noIssues");
   params.delete("clusters");
   params.delete("datacenters");
+  params.delete("networks");
   params.delete("search");
   params.delete("diskRangeMin");
   params.delete("diskRangeMax");


### PR DESCRIPTION
Implementation details
- Shared useChartDrillDown hook in vmNavigation.ts for consistent navigation
- Slice metadata (memoryRange, diskRange, clusterNames, networkNames) embedded at chart build time so clicks resolve reliably
- Disk tier parsing supports both GiB/TiB inventory labels and legacy TB buckets

Not drill-downable (by design)
- vCPU tiers — no backend filter for CPU count tiers
- NIC count — no nic_count filter in the API
- Shared disks — no confirmed backend filter
- Datacenter / CPU over-commitment cluster views — slices are aggregates, not VM groups

On the main report (/report/vms-overview) and group reports (/report/groups/:id), clicking these chart slices should switch to the VMs tab with the correct filters applied.