### PR TITLE
ECOPROJECT-4740 | fix: using new GroupsListInVMRow component to show groups column in VMs table

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/GroupsList.tsx
+++ b/apps/agent-ui/src/pages/Report/components/GroupsList.tsx
@@ -1,0 +1,65 @@
+import { css } from "@emotion/css";
+import { Label } from "@patternfly/react-core";
+import { EyeIcon, EyeSlashIcon } from "@patternfly/react-icons";
+import type React from "react";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import type { GroupListItem } from "./vmGroupMembership";
+
+const MAX_VISIBLE_GROUPS = 5;
+
+const groupItem = css`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+interface GroupsListProps {
+  groups: GroupListItem[];
+}
+
+export const GroupsList: React.FC<GroupsListProps> = ({ groups }) => {
+  const [showMore, setShowMore] = useState(false);
+  const maxNumberElements = Math.min(MAX_VISIBLE_GROUPS, groups.length);
+  const showMoreButton = groups.length > maxNumberElements;
+  const firstGroups = groups.slice(0, maxNumberElements);
+  const remainingGroups = groups.slice(maxNumberElements);
+
+  const renderGroup = (group: GroupListItem) => (
+    <div key={group.id} className={`${groupItem} pf-v6-u-mt-xs`}>
+      <Link to={`/report/groups/${group.id}`}>{group.name}</Link>
+    </div>
+  );
+
+  return (
+    <div>
+      {firstGroups.map(renderGroup)}
+      {showMore ? (
+        <>
+          {remainingGroups.map(renderGroup)}
+          <Label
+            isCompact
+            onClick={() => setShowMore(false)}
+            className="pf-v6-u-mt-xs"
+            icon={<EyeSlashIcon />}
+          >
+            Show less
+          </Label>
+        </>
+      ) : (
+        showMoreButton && (
+          <Label
+            isCompact
+            onClick={() => setShowMore(true)}
+            className="pf-v6-u-mt-xs"
+            icon={<EyeIcon />}
+          >
+            Show more
+          </Label>
+        )
+      )}
+    </div>
+  );
+};
+
+GroupsList.displayName = "GroupsList";

--- a/apps/agent-ui/src/pages/Report/components/VMTableGrid.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableGrid.tsx
@@ -15,7 +15,9 @@ import {
 import { EllipsisVIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import type React from "react";
+import { GroupsList } from "./GroupsList";
 import { formatMetric } from "./VMUtilizationMetrics";
+import type { GroupListItem } from "./vmGroupMembership";
 import {
   renderVmInspectionStatus,
   renderVmStatus,
@@ -73,7 +75,7 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
     setOpenActionMenuId,
   } = logic;
 
-  const { hideToolbarActions, disableVmNavigation, groupsDisplay } = variantUI;
+  const { hideToolbarActions, disableVmNavigation } = variantUI;
 
   return (
     <Table
@@ -121,269 +123,269 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
             </Td>
           </Tr>
         ) : (
-          displayVMs.map((vm, rowIndex) => (
-            <Tr key={vm.id}>
-              <Td
-                select={{
-                  rowIndex,
-                  onSelect: (_event, isSelected) => onSelectVM(vm, isSelected),
-                  isSelected:
-                    selectedVMs.has(vm.id) ||
-                    vm.inspectionStatus?.state === "running" ||
-                    vm.inspectionStatus?.state === "pending",
-                  isDisabled:
-                    vm.inspectionStatus?.state === "running" ||
-                    vm.inspectionStatus?.state === "pending",
-                }}
-              />
-              {isColumnVisible("name") && (
-                <Td dataLabel="Name" modifier="truncate">
-                  {onVMClick && !disableVmNavigation ? (
-                    <Tooltip content={vm.name}>
-                      <Button
-                        variant="link"
-                        isInline
-                        onClick={() => onVMClick(vm.id)}
-                      >
-                        {vm.name}
-                      </Button>
-                    </Tooltip>
-                  ) : (
-                    <Tooltip content={vm.name}>
-                      <span>{vm.name}</span>
-                    </Tooltip>
-                  )}
-                  {vm.migrationExcluded && (
-                    <div style={{ marginTop: "4px" }}>
-                      <Label isCompact color="grey">
-                        Excluded
-                      </Label>
-                    </div>
-                  )}
-                </Td>
-              )}
-              {isColumnVisible("labels") && (
-                <Td dataLabel="Labels">
-                  {(() => {
-                    const vmLabels: string[] | undefined = (
-                      vm as VirtualMachine & { labels?: string[] }
-                    ).labels;
-                    if (vmLabels && vmLabels.length > 0) {
-                      return (
-                        <LabelGroup numLabels={5}>
-                          {vmLabels.map((lbl: string) => (
-                            <Label key={lbl} isCompact>
-                              {lbl}
-                            </Label>
-                          ))}
-                        </LabelGroup>
-                      );
-                    }
-                    return "–";
-                  })()}
-                </Td>
-              )}
-              {isColumnVisible("groups") && (
-                <Td dataLabel="Groups">
-                  {vm.groups && vm.groups.length > 0 ? (
-                    groupsDisplay === "text" ? (
-                      vm.groups.join(", ")
-                    ) : (
-                      <LabelGroup numLabels={3}>
-                        {vm.groups.map((groupName) => (
-                          <Label key={groupName} isCompact>
-                            {groupName}
-                          </Label>
-                        ))}
-                      </LabelGroup>
-                    )
-                  ) : (
-                    "–"
-                  )}
-                </Td>
-              )}
-              {isColumnVisible("vCenterState") && (
-                <Td dataLabel="Status">{renderVmStatus(vm)}</Td>
-              )}
-              {isColumnVisible("migratable") && (
-                <Td dataLabel="Migration Readiness" modifier="fitContent">
-                  {vm.migratable === true
-                    ? "Ready"
-                    : vm.migratable === false
-                      ? "Not ready"
-                      : "Unknown"}
-                </Td>
-              )}
-              {isColumnVisible("id") && <Td dataLabel="ID">{vm.id}</Td>}
-
-              {isColumnVisible("maxCPU") && (
-                <Td dataLabel="Max CPU" modifier="fitContent">
-                  {formatMetric(vm.utilization_cpu_max)}
-                </Td>
-              )}
-              {isColumnVisible("maxRAM") && (
-                <Td dataLabel="Max RAM" modifier="fitContent">
-                  {formatMetric(vm.utilization_mem_max)}
-                </Td>
-              )}
-              {isColumnVisible("diskUsage") && (
-                <Td dataLabel="Disk usage" modifier="fitContent">
-                  {formatMetric(vm.utilization_disk)}
-                </Td>
-              )}
-              {isColumnVisible("datacenter") && (
-                <Td dataLabel="Data center">{vm.datacenter || "—"}</Td>
-              )}
-              {isColumnVisible("cluster") && (
-                <Td dataLabel="Cluster">{vm.cluster || "—"}</Td>
-              )}
-              {isColumnVisible("diskSize") && (
-                <Td dataLabel="Disk size">
-                  {formatDiskSize(vm.diskSize || 0)}
-                </Td>
-              )}
-              {isColumnVisible("memory") && (
-                <Td dataLabel="Memory size">
-                  {formatMemorySize(vm.memory || 0)}
-                </Td>
-              )}
-              {isColumnVisible("issues") && (
-                <Td dataLabel="Issues" modifier="fitContent">
-                  {vm.issueCount || 0}
-                </Td>
-              )}
-              {isColumnVisible("deepInspection") && (
-                <Td dataLabel="Deep inspection">
-                  {renderVmInspectionStatus(
-                    vm,
-                    onVMClick,
-                    cancelingInspectionVmIds,
-                  )}
-                </Td>
-              )}
-              {!hideToolbarActions && (
-                <Td isActionCell modifier="fitContent">
-                  <Dropdown
-                    isOpen={openActionMenuId === vm.id}
-                    onSelect={(_event, value) => {
-                      setOpenActionMenuId(null);
-                      if (value === "remove-from-group") {
-                        onRemoveFromGroup?.([vm.id]);
-                      }
-                    }}
-                    onOpenChange={(isOpen) =>
-                      setOpenActionMenuId(isOpen ? vm.id : null)
-                    }
-                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                      <MenuToggle
-                        ref={toggleRef}
-                        variant="plain"
-                        onClick={() =>
-                          setOpenActionMenuId(
-                            openActionMenuId === vm.id ? null : vm.id,
-                          )
-                        }
-                        isExpanded={openActionMenuId === vm.id}
-                      >
-                        <EllipsisVIcon />
-                      </MenuToggle>
-                    )}
-                    popperProps={{ position: "right" }}
-                  >
-                    <DropdownList>
-                      {isGroupRowActions && (
-                        <DropdownItem
-                          key="remove-from-group"
-                          value="remove-from-group"
-                          isDisabled={!onRemoveFromGroup}
+          displayVMs.map((vm, rowIndex) => {
+            const groupItems: GroupListItem[] =
+              "groupItems" in vm &&
+              Array.isArray((vm as { groupItems?: unknown }).groupItems)
+                ? (vm as { groupItems: GroupListItem[] }).groupItems
+                : [];
+            return (
+              <Tr key={vm.id}>
+                <Td
+                  select={{
+                    rowIndex,
+                    onSelect: (_event, isSelected) =>
+                      onSelectVM(vm, isSelected),
+                    isSelected:
+                      selectedVMs.has(vm.id) ||
+                      vm.inspectionStatus?.state === "running" ||
+                      vm.inspectionStatus?.state === "pending",
+                    isDisabled:
+                      vm.inspectionStatus?.state === "running" ||
+                      vm.inspectionStatus?.state === "pending",
+                  }}
+                />
+                {isColumnVisible("name") && (
+                  <Td dataLabel="Name" modifier="truncate">
+                    {onVMClick && !disableVmNavigation ? (
+                      <Tooltip content={vm.name}>
+                        <Button
+                          variant="link"
+                          isInline
+                          onClick={() => onVMClick(vm.id)}
                         >
-                          Remove from group
-                        </DropdownItem>
-                      )}
-                      {(() => {
-                        const vmState = vm.inspectionStatus?.state;
-                        if (vmState === "running" || vmState === "pending") {
-                          const isCanceling = cancelingInspectionVmIds?.has(
-                            vm.id,
-                          );
-                          return (
-                            <DropdownItem
-                              key="cancel-vm-inspection"
-                              isDisabled={isCanceling}
-                              onClick={() => openCancelInspectionConfirm(vm.id)}
-                            >
-                              Cancel deep inspection
-                            </DropdownItem>
-                          );
+                          {vm.name}
+                        </Button>
+                      </Tooltip>
+                    ) : (
+                      <Tooltip content={vm.name}>
+                        <span>{vm.name}</span>
+                      </Tooltip>
+                    )}
+                    {vm.migrationExcluded && (
+                      <div style={{ marginTop: "4px" }}>
+                        <Label isCompact color="grey">
+                          Excluded
+                        </Label>
+                      </div>
+                    )}
+                  </Td>
+                )}
+                {isColumnVisible("labels") && (
+                  <Td dataLabel="Labels">
+                    {(() => {
+                      const vmLabels: string[] | undefined = (
+                        vm as VirtualMachine & { labels?: string[] }
+                      ).labels;
+                      if (vmLabels && vmLabels.length > 0) {
+                        return (
+                          <LabelGroup numLabels={5}>
+                            {vmLabels.map((lbl: string) => (
+                              <Label key={lbl} isCompact>
+                                {lbl}
+                              </Label>
+                            ))}
+                          </LabelGroup>
+                        );
+                      }
+                      return "–";
+                    })()}
+                  </Td>
+                )}
+                {isColumnVisible("groups") && (
+                  <Td dataLabel="Groups">
+                    {groupItems.length > 0 ? (
+                      <GroupsList groups={groupItems} />
+                    ) : (
+                      "–"
+                    )}
+                  </Td>
+                )}
+                {isColumnVisible("vCenterState") && (
+                  <Td dataLabel="Status">{renderVmStatus(vm)}</Td>
+                )}
+                {isColumnVisible("migratable") && (
+                  <Td dataLabel="Migration Readiness" modifier="fitContent">
+                    {vm.migratable === true
+                      ? "Ready"
+                      : vm.migratable === false
+                        ? "Not ready"
+                        : "Unknown"}
+                  </Td>
+                )}
+                {isColumnVisible("id") && <Td dataLabel="ID">{vm.id}</Td>}
+
+                {isColumnVisible("maxCPU") && (
+                  <Td dataLabel="Max CPU" modifier="fitContent">
+                    {formatMetric(vm.utilization_cpu_max)}
+                  </Td>
+                )}
+                {isColumnVisible("maxRAM") && (
+                  <Td dataLabel="Max RAM" modifier="fitContent">
+                    {formatMetric(vm.utilization_mem_max)}
+                  </Td>
+                )}
+                {isColumnVisible("diskUsage") && (
+                  <Td dataLabel="Disk usage" modifier="fitContent">
+                    {formatMetric(vm.utilization_disk)}
+                  </Td>
+                )}
+                {isColumnVisible("datacenter") && (
+                  <Td dataLabel="Data center">{vm.datacenter || "—"}</Td>
+                )}
+                {isColumnVisible("cluster") && (
+                  <Td dataLabel="Cluster">{vm.cluster || "—"}</Td>
+                )}
+                {isColumnVisible("diskSize") && (
+                  <Td dataLabel="Disk size">
+                    {formatDiskSize(vm.diskSize || 0)}
+                  </Td>
+                )}
+                {isColumnVisible("memory") && (
+                  <Td dataLabel="Memory size">
+                    {formatMemorySize(vm.memory || 0)}
+                  </Td>
+                )}
+                {isColumnVisible("issues") && (
+                  <Td dataLabel="Issues" modifier="fitContent">
+                    {vm.issueCount || 0}
+                  </Td>
+                )}
+                {isColumnVisible("deepInspection") && (
+                  <Td dataLabel="Deep inspection">
+                    {renderVmInspectionStatus(
+                      vm,
+                      onVMClick,
+                      cancelingInspectionVmIds,
+                    )}
+                  </Td>
+                )}
+                {!hideToolbarActions && (
+                  <Td isActionCell modifier="fitContent">
+                    <Dropdown
+                      isOpen={openActionMenuId === vm.id}
+                      onSelect={(_event, value) => {
+                        setOpenActionMenuId(null);
+                        if (value === "remove-from-group") {
+                          onRemoveFromGroup?.([vm.id]);
                         }
-                        if (
-                          vmState === "completed" ||
-                          vmState === "error" ||
-                          vmState === "canceled"
-                        ) {
+                      }}
+                      onOpenChange={(isOpen) =>
+                        setOpenActionMenuId(isOpen ? vm.id : null)
+                      }
+                      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                        <MenuToggle
+                          ref={toggleRef}
+                          variant="plain"
+                          onClick={() =>
+                            setOpenActionMenuId(
+                              openActionMenuId === vm.id ? null : vm.id,
+                            )
+                          }
+                          isExpanded={openActionMenuId === vm.id}
+                        >
+                          <EllipsisVIcon />
+                        </MenuToggle>
+                      )}
+                      popperProps={{ position: "right" }}
+                    >
+                      <DropdownList>
+                        {isGroupRowActions && (
+                          <DropdownItem
+                            key="remove-from-group"
+                            value="remove-from-group"
+                            isDisabled={!onRemoveFromGroup}
+                          >
+                            Remove from group
+                          </DropdownItem>
+                        )}
+                        {(() => {
+                          const vmState = vm.inspectionStatus?.state;
+                          if (vmState === "running" || vmState === "pending") {
+                            const isCanceling = cancelingInspectionVmIds?.has(
+                              vm.id,
+                            );
+                            return (
+                              <DropdownItem
+                                key="cancel-vm-inspection"
+                                isDisabled={isCanceling}
+                                onClick={() =>
+                                  openCancelInspectionConfirm(vm.id)
+                                }
+                              >
+                                Cancel deep inspection
+                              </DropdownItem>
+                            );
+                          }
+                          if (
+                            vmState === "completed" ||
+                            vmState === "error" ||
+                            vmState === "canceled"
+                          ) {
+                            return (
+                              <DropdownItem
+                                key="rerun-inspection"
+                                onClick={() => onRunDeepInspection?.(vm.id)}
+                              >
+                                Re-run deep inspection
+                              </DropdownItem>
+                            );
+                          }
                           return (
                             <DropdownItem
-                              key="rerun-inspection"
+                              key="inspect"
                               onClick={() => onRunDeepInspection?.(vm.id)}
                             >
-                              Re-run deep inspection
+                              Run deep inspection
                             </DropdownItem>
                           );
-                        }
-                        return (
+                        })()}
+                        {vm.migrationExcluded ? (
                           <DropdownItem
-                            key="inspect"
-                            onClick={() => onRunDeepInspection?.(vm.id)}
+                            key="include-in-reports"
+                            onClick={() => onIncludeInReports?.([vm.id])}
                           >
-                            Run deep inspection
+                            Include in reports
                           </DropdownItem>
-                        );
-                      })()}
-                      {vm.migrationExcluded ? (
+                        ) : (
+                          <DropdownItem
+                            key="exclude-from-reports"
+                            onClick={() => onExcludeFromReports?.([vm.id])}
+                          >
+                            Exclude from reports
+                          </DropdownItem>
+                        )}
                         <DropdownItem
-                          key="include-in-reports"
-                          onClick={() => onIncludeInReports?.([vm.id])}
+                          key="edit-labels"
+                          onClick={() => onEditLabels?.([vm.id])}
                         >
-                          Include in reports
+                          Edit labels
                         </DropdownItem>
-                      ) : (
+                        {!isGroupRowActions && onAddToGroup && (
+                          <DropdownItem
+                            key="add-to-group"
+                            value="add-to-group"
+                            onClick={() => {
+                              setOpenActionMenuId(null);
+                              onAddToGroup([vm.id]);
+                            }}
+                          >
+                            Add to group
+                          </DropdownItem>
+                        )}
                         <DropdownItem
-                          key="exclude-from-reports"
-                          onClick={() => onExcludeFromReports?.([vm.id])}
+                          key="details"
+                          onClick={() => onVMClick?.(vm.id)}
                         >
-                          Exclude from reports
+                          View details
                         </DropdownItem>
-                      )}
-                      <DropdownItem
-                        key="edit-labels"
-                        onClick={() => onEditLabels?.([vm.id])}
-                      >
-                        Edit labels
-                      </DropdownItem>
-                      {!isGroupRowActions && onAddToGroup && (
-                        <DropdownItem
-                          key="add-to-group"
-                          value="add-to-group"
-                          onClick={() => {
-                            setOpenActionMenuId(null);
-                            onAddToGroup([vm.id]);
-                          }}
-                        >
-                          Add to group
-                        </DropdownItem>
-                      )}
-                      <DropdownItem
-                        key="details"
-                        onClick={() => onVMClick?.(vm.id)}
-                      >
-                        View details
-                      </DropdownItem>
-                    </DropdownList>
-                  </Dropdown>
-                </Td>
-              )}
-            </Tr>
-          ))
+                      </DropdownList>
+                    </Dropdown>
+                  </Td>
+                )}
+              </Tr>
+            );
+          })
         )}
       </Tbody>
     </Table>

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -16,8 +16,9 @@ import { VMDetailsPage } from "./VMDetailsPage";
 import { VMTable } from "./VMTable";
 import { filtersToByExpression, type VMFilters } from "./vmFilters";
 import {
-  buildVmIdToGroupNamesMap,
-  mergeVmGroupNames,
+  buildVmGroupMembership,
+  mergeVmGroupItems,
+  type VmGroupMembershipData,
 } from "./vmGroupMembership";
 import { cancelVmInspectionWithRetry } from "./vmInspectionUtils";
 import { fetchAllMatchingVmIds } from "./vmSelection";
@@ -149,9 +150,11 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   const [isRemoveFromGroupModalOpen, setIsRemoveFromGroupModalOpen] =
     useState(false);
   const [groupActionVMIds, setGroupActionVMIds] = useState<string[]>([]);
-  const [vmIdToGroupNames, setVmIdToGroupNames] = useState<
-    Map<string, string[]>
-  >(() => new Map());
+  const [vmGroupMembership, setVmGroupMembership] =
+    useState<VmGroupMembershipData>({
+      vmIdToGroups: {},
+      groupsByName: {},
+    });
 
   const basePath = useMemo(() => getAgentApiBasePath(agentApi), [agentApi]);
 
@@ -160,8 +163,8 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
       return;
     }
     try {
-      const map = await buildVmIdToGroupNamesMap(agentApi);
-      setVmIdToGroupNames(map);
+      const membership = await buildVmGroupMembership(agentApi);
+      setVmGroupMembership(membership);
     } catch (err) {
       console.error("Error loading VM group membership:", err);
     }
@@ -172,8 +175,8 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   }, [loadVmGroupMembership]);
 
   const vmsForTable = useMemo(
-    () => mergeVmGroupNames(vms, vmIdToGroupNames),
-    [vms, vmIdToGroupNames],
+    () => mergeVmGroupItems(vms, vmGroupMembership),
+    [vms, vmGroupMembership],
   );
 
   const visibleVms = useMemo(() => {
@@ -256,18 +259,12 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     const names = new Set<string>();
     for (const vmId of groupActionVMIds) {
       const vm = vmsForTable.find((v) => v.id === vmId);
-      const groups =
-        vm?.groups && vm.groups.length > 0
-          ? vm.groups
-          : vmIdToGroupNames.get(vmId);
-      if (groups) {
-        for (const groupName of groups) {
-          names.add(groupName);
-        }
+      for (const group of vm?.groupItems ?? []) {
+        names.add(group.name);
       }
     }
     return [...names];
-  }, [groupActionVMIds, groupContext, vmsForTable, vmIdToGroupNames]);
+  }, [groupActionVMIds, groupContext, vmsForTable]);
 
   const groupActionVmNames = useMemo(
     () =>

--- a/apps/agent-ui/src/pages/Report/components/useVMTableLogic.ts
+++ b/apps/agent-ui/src/pages/Report/components/useVMTableLogic.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import useLocalStorage from "../../../hooks/useLocalStorage";
 import { filtersToSearchParams, type VMFilters } from "./vmFilters";
+import type { VirtualMachineWithGroupItems } from "./vmGroupMembership";
 import {
   buildAppliedFilters,
   EMPTY_VM_TABLE_FILTER_SELECTION,
@@ -134,8 +135,8 @@ export function useVMTableLogic({
       return selectedVMs.size > 0;
     }
     for (const id of selectedVMs) {
-      const vm = vmById.get(id);
-      if (vm?.groups && vm.groups.length > 0) {
+      const vm = vmById.get(id) as VirtualMachineWithGroupItems | undefined;
+      if (vm?.groupItems && vm.groupItems.length > 0) {
         return true;
       }
     }

--- a/apps/agent-ui/src/pages/Report/components/vmGroupMembership.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmGroupMembership.ts
@@ -7,26 +7,38 @@ import { fetchAllMatchingVmIds } from "./vmSelection";
 
 const GROUP_LIST_PAGE_SIZE = 100;
 
-function addGroupName(
-  map: Map<string, string[]>,
+export type GroupListItem = {
+  id: string;
+  name: string;
+};
+
+export type VirtualMachineWithGroupItems = VirtualMachine & {
+  groupItems: GroupListItem[];
+};
+
+export type VmGroupMembershipData = {
+  vmIdToGroups: Record<string, GroupListItem[]>;
+  groupsByName: Record<string, GroupListItem>;
+};
+
+function addGroupToVm(
+  map: Record<string, GroupListItem[]>,
   vmId: string,
-  groupName: string,
+  group: GroupListItem,
 ): void {
-  const existing = map.get(vmId) ?? [];
-  if (existing.includes(groupName)) {
+  const existing = map[vmId] ?? [];
+  if (existing.some((item) => item.id === group.id)) {
     return;
   }
-  map.set(
-    vmId,
-    [...existing, groupName].sort((a, b) => a.localeCompare(b)),
-  );
+  map[vmId] = [...existing, group].sort((a, b) => a.name.localeCompare(b.name));
 }
 
-/** Builds vm id → group names from all groups (for VM overview when /vms omits groups). */
-export async function buildVmIdToGroupNamesMap(
+/** Builds vm id → groups and a name lookup from all groups. */
+export async function buildVmGroupMembership(
   agentApi: DefaultApiInterface,
-): Promise<Map<string, string[]>> {
-  const map = new Map<string, string[]>();
+): Promise<VmGroupMembershipData> {
+  const vmIdToGroups = Object.create(null) as Record<string, GroupListItem[]>;
+  const groupsByName = Object.create(null) as Record<string, GroupListItem>;
 
   const firstPage = await agentApi.listGroups({
     page: 1,
@@ -45,10 +57,19 @@ export async function buildVmIdToGroupNamesMap(
   }
 
   for (const group of allGroups) {
+    const groupItem = { id: group.id, name: group.name };
+    const existingByName = groupsByName[group.name];
+    if (existingByName !== undefined && existingByName.id !== group.id) {
+      throw new Error(
+        `Duplicate group name "${group.name}" with different ids: ${existingByName.id} and ${group.id}`,
+      );
+    }
+    groupsByName[group.name] = groupItem;
+
     const explicitIds = parseIdsFromFilter(group.filter);
     if (explicitIds !== null) {
       for (const vmId of explicitIds) {
-        addGroupName(map, vmId, group.name);
+        addGroupToVm(vmIdToGroups, vmId, groupItem);
       }
       continue;
     }
@@ -57,29 +78,29 @@ export async function buildVmIdToGroupNamesMap(
       byExpression: group.filter,
     });
     for (const vmId of matchingIds) {
-      addGroupName(map, vmId, group.name);
+      addGroupToVm(vmIdToGroups, vmId, groupItem);
     }
   }
 
-  return map;
+  return { vmIdToGroups, groupsByName };
 }
 
-export function mergeVmGroupNames(
+export function mergeVmGroupItems(
   vms: VirtualMachine[],
-  vmIdToGroupNames: Map<string, string[]>,
-): VirtualMachine[] {
-  if (vmIdToGroupNames.size === 0) {
-    return vms;
-  }
+  membership: VmGroupMembershipData,
+): VirtualMachineWithGroupItems[] {
+  const { vmIdToGroups, groupsByName } = membership;
 
   return vms.map((vm) => {
-    if (vm.groups && vm.groups.length > 0) {
-      return vm;
+    let groupItems = vmIdToGroups[vm.id];
+
+    if (!groupItems?.length && vm.groups?.length) {
+      groupItems = vm.groups
+        .map((name) => groupsByName[name])
+        .filter((group): group is GroupListItem => group !== undefined)
+        .sort((a, b) => a.name.localeCompare(b.name));
     }
-    const groups = vmIdToGroupNames.get(vm.id);
-    if (!groups || groups.length === 0) {
-      return vm;
-    }
-    return { ...vm, groups };
+
+    return { ...vm, groupItems: groupItems ?? [] };
   });
 }

--- a/apps/agent-ui/src/pages/Report/components/vmTableShared.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmTableShared.ts
@@ -211,7 +211,6 @@ export type VMTableVariantUI = {
   showManageColumns: boolean;
   hideToolbarActions: boolean;
   disableVmNavigation: boolean;
-  groupsDisplay: "labels" | "text";
   defaultColumnsKeys: ColumnKey[];
 };
 
@@ -220,21 +219,18 @@ export const VM_TABLE_VARIANT_UI: Record<VMTableVariant, VMTableVariantUI> = {
     showManageColumns: true,
     hideToolbarActions: false,
     disableVmNavigation: false,
-    groupsDisplay: "text",
     defaultColumnsKeys: [...ALL_COLUMN_KEYS],
   },
   groups: {
     showManageColumns: true,
     hideToolbarActions: false,
     disableVmNavigation: false,
-    groupsDisplay: "text",
     defaultColumnsKeys: ALL_COLUMN_KEYS.filter((k) => k !== "groups"),
   },
   compact: {
     showManageColumns: false,
     hideToolbarActions: true,
     disableVmNavigation: true,
-    groupsDisplay: "labels",
     defaultColumnsKeys: [...COMPACT_VISIBLE_COLUMNS],
   },
 };

--- a/apps/agent-ui/src/pages/Report/components/vmTableVariants.test.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmTableVariants.test.ts
@@ -12,7 +12,6 @@ describe("vmTableVariants", () => {
       showManageColumns: false,
       hideToolbarActions: true,
       disableVmNavigation: true,
-      groupsDisplay: "labels",
       defaultColumnsKeys: [
         "name",
         "labels",
@@ -23,8 +22,7 @@ describe("vmTableVariants", () => {
     });
   });
 
-  it("overview variant uses comma-separated groups and full toolbar", () => {
-    expect(VM_TABLE_VARIANT_UI.overview.groupsDisplay).toBe("text");
+  it("overview variant enables full toolbar and column management", () => {
     expect(VM_TABLE_VARIANT_UI.overview.showManageColumns).toBe(true);
     expect(VM_TABLE_VARIANT_UI.overview.hideToolbarActions).toBe(false);
   });


### PR DESCRIPTION
New GroupsListInVMRow component — Renders groups as a vertical list with:

- Links to /report/groups/{groupId}
- Up to 5 groups shown initially, then a Show more label (with Show less to collapse)

The Groups column should now be easier to scan, and each group name navigates to that group’s detail page.

[recording - 2026-06-05T125805.866.webm](https://github.com/user-attachments/assets/73cd4116-a3dc-4e89-b56b-769781f19ffd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `GroupsList` component that displays VM groups with a "Show more/less" toggle, initially showing up to 5 groups with links to group details.

* **Bug Fixes**
  * Improved group membership data handling and display consistency in the VM table.

* **Refactor**
  * Restructured internal group membership handling and column configuration for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->