### PR TITLE
ECOPROJECT-4603 | fix: fix per-VM deep inspection cancel and improve cancel UX

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/VMDetailsPage.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMDetailsPage.tsx
@@ -49,6 +49,7 @@ import type React from "react";
 import { useEffect, useState } from "react";
 import { Symbols } from "../../../main/Symbols";
 import { formatMetric } from "./VMUtilizationMetrics";
+import { isLikelyCanceledInspectionError } from "./vmInspectionUtils";
 
 const MB_IN_GB = 1024;
 
@@ -214,7 +215,9 @@ export const VMDetailsPage: React.FC<VMDetailsPageProps> = ({
               !c.message?.toLowerCase().includes("no inspection concerns") &&
               !c.label?.toLowerCase().includes("no inspection concerns"),
           );
-          const hasError = !!inspectionStatus.error;
+          const hasError =
+            !!inspectionStatus.error &&
+            !isLikelyCanceledInspectionError(inspectionStatus.error);
           const hasContent = hasError || concerns.length > 0;
 
           return (
@@ -268,7 +271,10 @@ export const VMDetailsPage: React.FC<VMDetailsPageProps> = ({
                         ? "Inspection pending…"
                         : inspectionStatus.state === "running"
                           ? "Inspection in progress…"
-                          : inspectionStatus.state === "canceled"
+                          : inspectionStatus.state === "canceled" ||
+                              isLikelyCanceledInspectionError(
+                                inspectionStatus.error,
+                              )
                             ? "Inspection was canceled"
                             : inspectionStatus.state === "error"
                               ? "Inspection failed"

--- a/apps/agent-ui/src/pages/Report/components/VMTable.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTable.tsx
@@ -35,6 +35,7 @@ export const VMTable: React.FC<VMTableProps> = ({
   showExcludedVMs = true,
   onShowExcludedVMsChange,
   inspectionActive = false,
+  cancelingInspectionVmIds,
   onCancelInspection,
   onResetInspection,
   variant = "overview",
@@ -101,10 +102,12 @@ export const VMTable: React.FC<VMTableProps> = ({
         onAddToGroup={onAddToGroup}
         onRemoveFromGroup={onRemoveFromGroup}
         openCancelInspectionConfirm={logic.openCancelInspectionConfirm}
+        cancelingInspectionVmIds={cancelingInspectionVmIds}
       />
 
       <VMTableModals
         logic={logic}
+        cancelingInspectionVmIds={cancelingInspectionVmIds}
         onCancelInspection={onCancelInspection}
         onExcludeFromReports={onExcludeFromReports}
         onIncludeInReports={onIncludeInReports}

--- a/apps/agent-ui/src/pages/Report/components/VMTableGrid.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableGrid.tsx
@@ -43,6 +43,7 @@ export interface VMTableGridProps {
   onAddToGroup?: (vmIds: string[]) => void;
   onRemoveFromGroup?: (vmIds: string[]) => void;
   openCancelInspectionConfirm: (vmId: string) => void;
+  cancelingInspectionVmIds?: Set<string>;
 }
 
 export const VMTableGrid: React.FC<VMTableGridProps> = ({
@@ -60,6 +61,7 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
   onAddToGroup,
   onRemoveFromGroup,
   openCancelInspectionConfirm,
+  cancelingInspectionVmIds,
 }) => {
   const {
     columns,
@@ -252,7 +254,11 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
               )}
               {isColumnVisible("deepInspection") && (
                 <Td dataLabel="Deep inspection">
-                  {renderVmInspectionStatus(vm, onVMClick)}
+                  {renderVmInspectionStatus(
+                    vm,
+                    onVMClick,
+                    cancelingInspectionVmIds,
+                  )}
                 </Td>
               )}
               {!hideToolbarActions && (
@@ -297,9 +303,13 @@ export const VMTableGrid: React.FC<VMTableGridProps> = ({
                       {(() => {
                         const vmState = vm.inspectionStatus?.state;
                         if (vmState === "running" || vmState === "pending") {
+                          const isCanceling = cancelingInspectionVmIds?.has(
+                            vm.id,
+                          );
                           return (
                             <DropdownItem
                               key="cancel-vm-inspection"
+                              isDisabled={isCanceling}
                               onClick={() => openCancelInspectionConfirm(vm.id)}
                             >
                               Cancel deep inspection

--- a/apps/agent-ui/src/pages/Report/components/VMTableModals.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VMTableModals.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Button,
   Content,
   Modal,
@@ -7,11 +8,14 @@ import {
   ModalHeader,
 } from "@patternfly/react-core";
 import type React from "react";
+import { useState } from "react";
+import { extractCancelInspectionErrorMessage } from "./vmInspectionUtils";
 import type { VMTableLogic } from "./vmTableTypes";
 
 export interface VMTableModalsProps {
   logic: VMTableLogic;
-  onCancelInspection?: (vmId: string) => void;
+  cancelingInspectionVmIds?: Set<string>;
+  onCancelInspection?: (vmId: string) => Promise<void>;
   onExcludeFromReports?: (vmIds: string[]) => Promise<void>;
   onIncludeInReports?: (vmIds: string[]) => Promise<void>;
   onSelectionChange?: (selected: Set<string>) => void;
@@ -19,11 +23,14 @@ export interface VMTableModalsProps {
 
 export const VMTableModals: React.FC<VMTableModalsProps> = ({
   logic,
+  cancelingInspectionVmIds,
   onCancelInspection,
   onExcludeFromReports,
   onIncludeInReports,
   onSelectionChange,
 }) => {
+  const [cancelError, setCancelError] = useState<string | null>(null);
+
   const {
     cancelInspectionVmId,
     closeCancelInspectionConfirm,
@@ -40,11 +47,19 @@ export const VMTableModals: React.FC<VMTableModalsProps> = ({
     selectedIncludedIds,
   } = logic;
 
+  const isCancelLoading =
+    cancelInspectionVmId !== null &&
+    (cancelingInspectionVmIds?.has(cancelInspectionVmId) ?? false);
+
   return (
     <>
       <Modal
         isOpen={cancelInspectionVmId !== null}
-        onClose={closeCancelInspectionConfirm}
+        onClose={() => {
+          if (isCancelLoading) return;
+          setCancelError(null);
+          closeCancelInspectionConfirm();
+        }}
         aria-labelledby="cancel-inspection-title"
         aria-describedby="cancel-inspection-body"
         variant="small"
@@ -55,6 +70,15 @@ export const VMTableModals: React.FC<VMTableModalsProps> = ({
           labelId="cancel-inspection-title"
         />
         <ModalBody id="cancel-inspection-body">
+          {cancelError && (
+            <Alert
+              variant="danger"
+              title="Unable to cancel inspection"
+              isInline
+            >
+              {cancelError}
+            </Alert>
+          )}
           <Content component="p">
             {(() => {
               const vmName = cancelInspectionVmId
@@ -75,16 +99,30 @@ export const VMTableModals: React.FC<VMTableModalsProps> = ({
         <ModalFooter>
           <Button
             variant="danger"
-            onClick={() => {
-              if (cancelInspectionVmId) {
-                onCancelInspection?.(cancelInspectionVmId);
+            isLoading={isCancelLoading}
+            isDisabled={isCancelLoading}
+            onClick={async () => {
+              if (!cancelInspectionVmId || !onCancelInspection) return;
+              setCancelError(null);
+              try {
+                await onCancelInspection(cancelInspectionVmId);
+                closeCancelInspectionConfirm();
+              } catch (err) {
+                console.error("Error canceling inspection:", err);
+                setCancelError(await extractCancelInspectionErrorMessage(err));
               }
-              closeCancelInspectionConfirm();
             }}
           >
             Confirm
           </Button>
-          <Button variant="link" onClick={closeCancelInspectionConfirm}>
+          <Button
+            variant="link"
+            isDisabled={isCancelLoading}
+            onClick={() => {
+              setCancelError(null);
+              closeCancelInspectionConfirm();
+            }}
+          >
             Cancel
           </Button>
         </ModalFooter>

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -19,6 +19,7 @@ import {
   buildVmIdToGroupNamesMap,
   mergeVmGroupNames,
 } from "./vmGroupMembership";
+import { cancelVmInspectionWithRetry } from "./vmInspectionUtils";
 import { fetchAllMatchingVmIds } from "./vmSelection";
 
 async function updateVmMigrationExcluded(
@@ -125,7 +126,13 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   // first response still carries stale terminal states from a previous run.
   const MIN_POLL_TICKS_BEFORE_DONE = 2;
   // Fallback ceiling to avoid polling forever.
-  const MAX_POLL_TICKS = 60; // 60 × 5 s = 5 min
+  const MAX_POLL_TICKS = 60;
+  const POLL_INTERVAL_MS = 5000;
+  const CANCEL_POLL_INTERVAL_MS = 2000;
+
+  const [cancelingInspectionVmIds, setCancelingInspectionVmIds] = useState(
+    () => new Set<string>(),
+  );
 
   useEffect(() => {
     onRefreshVMsRef.current = onRefreshVMs;
@@ -393,14 +400,42 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     }
   }, []);
 
+  const shouldPoll = inspectionActive || cancelingInspectionVmIds.size > 0;
+  const pollIntervalMs =
+    cancelingInspectionVmIds.size > 0
+      ? CANCEL_POLL_INTERVAL_MS
+      : POLL_INTERVAL_MS;
+
+  useEffect(() => {
+    if (!shouldPoll) {
+      stopPolling();
+      return;
+    }
+
+    stopPolling();
+    pollingRef.current = setInterval(() => {
+      pollTicksRef.current += 1;
+      onRefreshVMsRef.current?.();
+    }, pollIntervalMs);
+
+    return () => stopPolling();
+  }, [shouldPoll, pollIntervalMs, stopPolling]);
+
   const handleCancelInspection = useCallback(
     async (vmId: string) => {
       if (!agentApi) return;
+
+      setCancelingInspectionVmIds((prev) => new Set(prev).add(vmId));
       try {
-        await agentApi.removeVMFromInspection({ id: vmId });
-        onRefreshVMs?.();
+        await cancelVmInspectionWithRetry(agentApi, vmId);
+        await onRefreshVMs?.();
       } catch (err) {
-        console.error("Error canceling inspection:", err);
+        setCancelingInspectionVmIds((prev) => {
+          const next = new Set(prev);
+          next.delete(vmId);
+          return next;
+        });
+        throw err;
       }
     },
     [agentApi, onRefreshVMs],
@@ -426,14 +461,13 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     if (!agentApi) return;
     try {
       await agentApi.stopInspection();
-      stopPolling();
       setInspectionActive(false);
       onRefreshVMs?.();
     } catch (err) {
       console.error("Error stopping inspection for reset:", err);
     }
     setIsInspectionModalOpen(true);
-  }, [agentApi, onRefreshVMs, stopPolling]);
+  }, [agentApi, onRefreshVMs]);
 
   const handleInspectionStarted = useCallback(() => {
     seenRunningRef.current = false;
@@ -441,13 +475,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     setInspectionActive(true);
     setSelectedVMs(new Set());
     onRefreshVMsRef.current?.();
-
-    stopPolling();
-    pollingRef.current = setInterval(() => {
-      pollTicksRef.current += 1;
-      onRefreshVMsRef.current?.();
-    }, 5000);
-  }, [stopPolling]);
+  }, []);
 
   useEffect(() => {
     if (!inspectionActive) return;
@@ -481,10 +509,27 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     const exhausted = ticks >= MAX_POLL_TICKS && !hasRunningOrPending;
 
     if (seenAndDone || waitedAndDone || exhausted) {
-      stopPolling();
       setInspectionActive(false);
     }
-  }, [vms, inspectionActive, stopPolling]);
+  }, [vms, inspectionActive]);
+
+  useEffect(() => {
+    if (cancelingInspectionVmIds.size === 0) return;
+
+    setCancelingInspectionVmIds((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const vmId of prev) {
+        const vm = vms.find((v) => v.id === vmId);
+        const state = vm?.inspectionStatus?.state;
+        if (state && state !== "running" && state !== "pending") {
+          next.delete(vmId);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [vms, cancelingInspectionVmIds.size]);
 
   useEffect(() => {
     return () => stopPolling();
@@ -535,6 +580,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
         showExcludedVMs={showExcludedVMs}
         onShowExcludedVMsChange={onShowExcludedVMsChange}
         inspectionActive={inspectionActive}
+        cancelingInspectionVmIds={cancelingInspectionVmIds}
         onCancelInspection={handleCancelInspection}
         onResetInspection={handleResetInspection}
       />

--- a/apps/agent-ui/src/pages/Report/components/vmInspectionUtils.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmInspectionUtils.ts
@@ -1,0 +1,72 @@
+import type { DefaultApiInterface } from "@openshift-migration-advisor/agent-sdk";
+import { ResponseError } from "@openshift-migration-advisor/agent-sdk";
+
+const CANCEL_RETRY_DELAY_MS = 2000;
+const CANCEL_MAX_ATTEMPTS = 5;
+
+/**
+ * Heuristic: the backend may report user-initiated mid-run cancels as `error`
+ * (virt-inspector killed with exit code 1) rather than state `canceled`.
+ * Natural virt-inspector crashes can match the same pattern — a distinct
+ * backend flag would be needed to tell them apart reliably.
+ */
+export function isLikelyCanceledInspectionError(error?: string): boolean {
+  if (!error) return false;
+  return /virt-inspector failed \(exit code/i.test(error);
+}
+
+function isRetryableCancelError(err: unknown): boolean {
+  if (!(err instanceof ResponseError)) return false;
+  const status = err.response?.status;
+  return status === 400 || status === 409 || status === 503;
+}
+
+export async function cancelVmInspectionWithRetry(
+  agentApi: DefaultApiInterface,
+  vmId: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < CANCEL_MAX_ATTEMPTS; attempt++) {
+    try {
+      await agentApi.removeVMFromInspection({ id: vmId });
+      return;
+    } catch (err) {
+      const isLastAttempt = attempt === CANCEL_MAX_ATTEMPTS - 1;
+      if (!isRetryableCancelError(err) || isLastAttempt) {
+        throw err;
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, CANCEL_RETRY_DELAY_MS),
+      );
+    }
+  }
+}
+
+export async function extractCancelInspectionErrorMessage(
+  err: unknown,
+): Promise<string> {
+  if (err instanceof ResponseError) {
+    try {
+      const body = await err.response.json();
+      if (typeof body?.message === "string" && body.message) {
+        return body.message;
+      }
+      if (typeof body?.error === "string" && body.error) {
+        return body.error;
+      }
+    } catch {
+      // fall through to status-based message
+    }
+
+    const status = err.response?.status;
+    if (status === 400) {
+      return "This VM cannot be canceled right now. The inspector may still be finishing the current step.";
+    }
+    if (status === 404) {
+      return "This VM is no longer in the inspection queue.";
+    }
+  }
+
+  return err instanceof Error
+    ? err.message
+    : "Failed to cancel deep inspection";
+}

--- a/apps/agent-ui/src/pages/Report/components/vmTableCellRenderers.tsx
+++ b/apps/agent-ui/src/pages/Report/components/vmTableCellRenderers.tsx
@@ -13,6 +13,7 @@ import {
   ExclamationTriangleIcon,
 } from "@patternfly/react-icons";
 import type React from "react";
+import { isLikelyCanceledInspectionError } from "./vmInspectionUtils";
 import { statusLabels } from "./vmTableShared";
 
 export function renderVmStatus(vm: VirtualMachine): React.ReactNode {
@@ -49,9 +50,18 @@ export function renderVmStatus(vm: VirtualMachine): React.ReactNode {
 export function renderVmInspectionStatus(
   vm: VirtualMachine,
   onVMClick?: (vmId: string) => void,
+  cancelingVmIds?: Set<string>,
 ): React.ReactNode {
   const status = vm.inspectionStatus;
   if (!status) return "Not run";
+
+  if (cancelingVmIds?.has(vm.id)) {
+    return (
+      <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+        <Spinner size="sm" /> Canceling
+      </span>
+    );
+  }
 
   const state = status.state;
   const goToDetail = onVMClick ? () => onVMClick(vm.id) : undefined;
@@ -65,6 +75,16 @@ export function renderVmInspectionStatus(
   }
 
   if (state === "error") {
+    if (isLikelyCanceledInspectionError(status.error)) {
+      return (
+        <span style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <Label color="grey" isCompact>
+            Canceled
+          </Label>
+        </span>
+      );
+    }
+
     const concernCount = vm.inspectionConcernCount || 0;
 
     if (concernCount === 0) {

--- a/apps/agent-ui/src/pages/Report/components/vmTableTypes.ts
+++ b/apps/agent-ui/src/pages/Report/components/vmTableTypes.ts
@@ -38,7 +38,8 @@ export interface VMTableProps {
   showExcludedVMs?: boolean;
   onShowExcludedVMsChange?: (show: boolean) => void;
   inspectionActive?: boolean;
-  onCancelInspection?: (vmId: string) => void;
+  cancelingInspectionVmIds?: Set<string>;
+  onCancelInspection?: (vmId: string) => Promise<void>;
   onResetInspection?: () => void;
   variant?: VMTableVariant;
 }


### PR DESCRIPTION
- Use DELETE /vms/{id}/inspection (removeVMFromInspection) instead of DELETE /inspector (stopInspection) when canceling from a VM row, so canceling one VM no longer stops all running inspections.

- Improve cancel reliability and feedback: retry on transient backend errors, show loading/error in the confirm modal, display a "Canceling" row state until the VM reaches a terminal status, and poll more frequently after cancel.

- Treat virt-inspector exit errors from user-initiated stops as "Canceled" in the UI for consistent display.