### PR TITLE
ECOPROJECT-4647 | refactor: Use the new endpoint to get cluster sizing

### DIFF
--- a/apps/agent-ui/package.json
+++ b/apps/agent-ui/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.0",
     "@migration-planner-ui/ioc": "workspace:*",
-    "@openshift-migration-advisor/agent-sdk": "0.12.0-f90a4cad59fa",
+    "@openshift-migration-advisor/agent-sdk": "0.12.0-b4cc95d9b3d0",
     "@patternfly/react-charts": "^8.0.0",
     "@patternfly/react-core": "^6.4.3",
     "@patternfly/react-icons": "^6.4.0",

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -211,19 +211,13 @@ export const ReportContainer: React.FC = () => {
 
     const fetchUtilizationMetrics = async () => {
       try {
-        const byExpression = `cluster_id='${selectedClusterId}'`;
-        const response = await agentApi.getLatestRightsizingClusters({
-          byExpression,
+        const response = await agentApi.getClusterUtilization({
+          clusterId: selectedClusterId,
         });
 
         // Only update state if the effect hasn't been cleaned up
         if (!cancelled) {
-          // Find cluster metrics for the selected cluster
-          const clusterMetrics = response.clusters?.find(
-            (cluster) => cluster.cluster_id === selectedClusterId,
-          );
-
-          setUtilizationMetrics(clusterMetrics || null);
+          setUtilizationMetrics(response.cluster);
         }
       } catch (err) {
         if (!cancelled) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,7 +564,7 @@ __metadata:
   dependencies:
     "@emotion/css": "npm:^11.13.0"
     "@migration-planner-ui/ioc": "workspace:*"
-    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-f90a4cad59fa"
+    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-b4cc95d9b3d0"
     "@patternfly/react-charts": "npm:^8.0.0"
     "@patternfly/react-core": "npm:^6.4.3"
     "@patternfly/react-icons": "npm:^6.4.0"
@@ -607,10 +607,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openshift-migration-advisor/agent-sdk@npm:0.12.0-f90a4cad59fa":
-  version: 0.12.0-f90a4cad59fa
-  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-f90a4cad59fa"
-  checksum: 10c0/127ceeb5c58c237d2eab2e6b2699a5ca164b9ca92f70749758a29dc4c577eb812e45f35598d47618e0c4ea30783af7a39c2354730cde4ad9ddd7e97dd71b9c5f
+"@openshift-migration-advisor/agent-sdk@npm:0.12.0-b4cc95d9b3d0":
+  version: 0.12.0-b4cc95d9b3d0
+  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-b4cc95d9b3d0"
+  checksum: 10c0/3d7b4d80cc76a89c14cd9f53e16dc5d5084ea6adaf423d778e35af0fe273461f906ce2955f8831087b195e8059612ebd98071947db8452326892a5dc17d8d90c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use the new endpoint to get cluster sizing instead of listing all the clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies and optimized cluster utilization metrics fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->