### PR TITLE
ECOPROJECT-4761 | fix: assessment report VM count has to update after excluding a VM from migration

### DIFF
--- a/apps/agent-ui/src/pages/Report/GroupDetailPage.tsx
+++ b/apps/agent-ui/src/pages/Report/GroupDetailPage.tsx
@@ -37,6 +37,7 @@ import {
 } from "react-router-dom";
 import { useAgentStatus } from "../../common/AgentStatusContext";
 import { Symbols } from "../../main/Symbols";
+import { getAgentApiBasePath } from "./agentApiConfig";
 import { buildClusterViewModel, type ClusterOption } from "./clusterView";
 import { ApplicationsView, Dashboard, VirtualMachinesView } from "./components";
 import { DeleteGroupModal } from "./components/DeleteGroupModal";
@@ -48,7 +49,14 @@ import {
   searchParamsToFilters,
 } from "./components/vmFilters";
 import { Header } from "./Header";
-import { getInventoryAggregateView } from "./inventoryParsing";
+import {
+  adjustInventoryForMigrationExcludedChange,
+  fetchInventoryAfterMigrationChange,
+  fetchInventoryFromApi,
+  getInventoryAggregateView,
+  type MigrationExcludedInventoryChange,
+  resolveInventoryOnReload,
+} from "./inventoryParsing";
 import {
   buildApplicationsTabUrl,
   buildOverviewTabUrl,
@@ -59,6 +67,7 @@ import {
   resolveReportTab,
 } from "./reportTabNavigation";
 import { useApplicationsData } from "./useApplicationsData";
+import { normalizeVirtualMachines } from "./virtualMachineParsing";
 
 export const GroupDetailPage: React.FC = () => {
   const { groupId } = useParams<{ groupId: string }>();
@@ -219,7 +228,7 @@ export const GroupDetailPage: React.FC = () => {
         });
 
         if (currentRequestId === vmsRequestIdRef.current) {
-          setVmsList(response.vms || []);
+          setVmsList(normalizeVirtualMachines(response.vms));
           setVmsTotalCount(response.total || 0);
         }
       } catch (err) {
@@ -269,7 +278,7 @@ export const GroupDetailPage: React.FC = () => {
         agentApi.getVMLabels().catch(() => null),
       ]);
       if (vmsRefreshIdRef.current === reqId) {
-        setVmsList(response.vms || []);
+        setVmsList(normalizeVirtualMachines(response.vms));
         setVmsTotalCount(response.total || 0);
         setAvailableFilterOptions((prev) => ({
           ...prev,
@@ -288,6 +297,87 @@ export const GroupDetailPage: React.FC = () => {
     vmsPage,
     vmsPageSize,
   ]);
+
+  const reloadAssessmentInventory = useCallback(async () => {
+    if (!groupId) {
+      return;
+    }
+
+    try {
+      const basePath = getAgentApiBasePath(agentApi);
+      const fetchedInventory = await fetchInventoryFromApi(basePath, {
+        groupId,
+      });
+      if (!fetchedInventory) {
+        return;
+      }
+
+      setInventory((current) => {
+        if (!current) {
+          return fetchedInventory;
+        }
+
+        return resolveInventoryOnReload(current, fetchedInventory);
+      });
+    } catch (err) {
+      console.error("Error reloading group assessment inventory:", err);
+    }
+  }, [agentApi, groupId]);
+
+  const refreshGroupInventory = useCallback(
+    async (change: MigrationExcludedInventoryChange): Promise<void> => {
+      if (!groupId) {
+        return;
+      }
+
+      setVmsList((current) =>
+        current.map((vm) =>
+          change.vmIds.includes(vm.id)
+            ? { ...vm, migrationExcluded: change.excluded }
+            : vm,
+        ),
+      );
+
+      let previousTotal: number | undefined;
+      let optimisticInventory: Inventory | null = null;
+
+      setInventory((current) => {
+        if (!current) {
+          return current;
+        }
+        previousTotal = getInventoryAggregateView(current).vms?.total;
+        optimisticInventory = adjustInventoryForMigrationExcludedChange(
+          current,
+          change.vmIds,
+          change.excluded,
+          change.affectedVms,
+        );
+        return optimisticInventory;
+      });
+
+      try {
+        const basePath = getAgentApiBasePath(agentApi);
+        const resolved = await fetchInventoryAfterMigrationChange(
+          basePath,
+          change,
+          previousTotal,
+          optimisticInventory,
+          { groupId },
+        );
+        if (resolved) {
+          setInventory((current) => {
+            if (!current) {
+              return resolved;
+            }
+            return resolveInventoryOnReload(current, resolved);
+          });
+        }
+      } catch (err) {
+        console.error("Error refreshing group inventory:", err);
+      }
+    },
+    [agentApi, groupId],
+  );
 
   const reloadGroupMembership = useCallback(async () => {
     if (!groupId) {
@@ -322,6 +412,7 @@ export const GroupDetailPage: React.FC = () => {
       newParams = buildApplicationsTabUrl(searchParams);
     } else {
       newParams = buildOverviewTabUrl(searchParams);
+      void reloadAssessmentInventory();
     }
     setSearchParams(newParams, { replace: true });
   };
@@ -527,6 +618,7 @@ export const GroupDetailPage: React.FC = () => {
                 {clusterView.viewInfra && clusterView.viewVms ? (
                   <div style={{ marginTop: "24px" }}>
                     <Dashboard
+                      key={`group-assessment-${clusterView.viewVms.total ?? 0}-${clusterView.selectionId}`}
                       infra={clusterView.viewInfra}
                       cpuCores={clusterView.cpuCores}
                       ramGB={clusterView.ramGB}
@@ -565,6 +657,7 @@ export const GroupDetailPage: React.FC = () => {
                   availableFilterOptions={availableFilterOptions}
                   agentApi={agentApi}
                   onRefreshVMs={refreshVMs}
+                  onRefreshInventory={refreshGroupInventory}
                   onGroupMembershipChanged={reloadGroupMembership}
                   showExcludedVMs={showExcludedVMs}
                   onShowExcludedVMsChange={(show) => {

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -34,6 +34,7 @@ import {
   DataSharingModal,
 } from "../../common/components/index";
 import { Symbols } from "../../main/Symbols";
+import { getAgentApiBasePath } from "./agentApiConfig";
 import { buildClusterViewModel, type ClusterOption } from "./clusterView";
 import {
   ApplicationsView,
@@ -47,7 +48,14 @@ import {
   searchParamsToFilters,
 } from "./components/vmFilters";
 import { Header } from "./Header";
-import { inventoryFromGetInventoryResponse } from "./inventoryParsing";
+import {
+  adjustInventoryForMigrationExcludedChange,
+  fetchInventoryAfterMigrationChange,
+  fetchInventoryFromApi,
+  getInventoryAggregateView,
+  type MigrationExcludedInventoryChange,
+  resolveInventoryOnReload,
+} from "./inventoryParsing";
 import {
   buildApplicationsTabUrl,
   buildOverviewTabUrl,
@@ -58,6 +66,7 @@ import {
   resolveReportTab,
 } from "./reportTabNavigation";
 import { useApplicationsData } from "./useApplicationsData";
+import { normalizeVirtualMachines } from "./virtualMachineParsing";
 
 export const ReportContainer: React.FC = () => {
   const agentApi = useInjection<DefaultApiInterface>(Symbols.AgentApi);
@@ -88,6 +97,7 @@ export const ReportContainer: React.FC = () => {
   const [vmsPageSize, setVmsPageSize] = useState(20);
   const [vmsSortFields, setVmsSortFields] = useState<string[]>([]);
   const [showExcludedVMs, setShowExcludedVMs] = useState(true);
+  const [inventoryRevision, setInventoryRevision] = useState(0);
 
   // Store all available filter options (fetched once for filter UI)
   const [availableFilterOptions, setAvailableFilterOptions] = useState<{
@@ -131,13 +141,92 @@ export const ReportContainer: React.FC = () => {
     }
   }, [searchParams, activeTab]);
 
+  const fetchInventory = useCallback(async (): Promise<Inventory | null> => {
+    const basePath = getAgentApiBasePath(agentApi);
+    return fetchInventoryFromApi(basePath);
+  }, [agentApi]);
+
+  const reloadAssessmentInventory = useCallback(async () => {
+    try {
+      const fetchedInventory = await fetchInventory();
+      if (!fetchedInventory) {
+        return;
+      }
+
+      setInventory((current) => {
+        if (!current) {
+          return fetchedInventory;
+        }
+
+        return resolveInventoryOnReload(current, fetchedInventory);
+      });
+    } catch (err) {
+      console.error("Error reloading assessment inventory:", err);
+    }
+  }, [fetchInventory]);
+
+  const refreshInventory = useCallback(
+    async (change: MigrationExcludedInventoryChange): Promise<void> => {
+      setVmsList((current) =>
+        current.map((vm) =>
+          change.vmIds.includes(vm.id)
+            ? { ...vm, migrationExcluded: change.excluded }
+            : vm,
+        ),
+      );
+
+      let previousTotal: number | undefined;
+      let optimisticInventory: Inventory | null = null;
+
+      setInventory((current) => {
+        if (!current) {
+          return current;
+        }
+        previousTotal = getInventoryAggregateView(current).vms?.total;
+        optimisticInventory = adjustInventoryForMigrationExcludedChange(
+          current,
+          change.vmIds,
+          change.excluded,
+          change.affectedVms,
+        );
+        return optimisticInventory;
+      });
+
+      if (optimisticInventory) {
+        setInventoryRevision((revision) => revision + 1);
+      }
+
+      try {
+        const basePath = getAgentApiBasePath(agentApi);
+        const resolved = await fetchInventoryAfterMigrationChange(
+          basePath,
+          change,
+          previousTotal,
+          optimisticInventory,
+        );
+        if (resolved) {
+          setInventory((current) => {
+            if (!current) {
+              return resolved;
+            }
+            return resolveInventoryOnReload(current, resolved);
+          });
+          setInventoryRevision((revision) => revision + 1);
+        }
+      } catch (err) {
+        console.error("Error refreshing inventory:", err);
+      }
+    },
+    [agentApi],
+  );
+
   // Fetch inventory only (agent status comes from context)
   useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const response = await agentApi.getInventory({});
-        setInventory(inventoryFromGetInventoryResponse(response));
+        const nextInventory = await fetchInventory();
+        setInventory(nextInventory);
       } catch (err) {
         console.error("Error fetching inventory:", err);
 
@@ -155,7 +244,7 @@ export const ReportContainer: React.FC = () => {
     };
 
     fetchData();
-  }, [agentApi]);
+  }, [fetchInventory]);
 
   // Fetch cluster utilization metrics
   useEffect(() => {
@@ -245,7 +334,7 @@ export const ReportContainer: React.FC = () => {
         });
 
         if (currentRequestId === vmsRequestIdRef.current) {
-          setVmsList(response.vms || []);
+          setVmsList(normalizeVirtualMachines(response.vms));
           setVmsTotalCount(response.total || 0);
         }
       } catch (err) {
@@ -287,7 +376,7 @@ export const ReportContainer: React.FC = () => {
         agentApi.getVMLabels().catch(() => null),
       ]);
       if (vmsRefreshIdRef.current === reqId) {
-        setVmsList(response.vms || []);
+        setVmsList(normalizeVirtualMachines(response.vms));
         setVmsTotalCount(response.total || 0);
         setAvailableFilterOptions((prev) => ({
           ...prev,
@@ -356,19 +445,14 @@ export const ReportContainer: React.FC = () => {
     );
   }
 
-  // Extract data from inventory
-  const infra = inventory.vcenter?.infra;
-  const vms = inventory.vcenter?.vms;
-  const clusters = inventory.clusters || {};
+  const aggregateView = getInventoryAggregateView(inventory);
+  const totalVMs = aggregateView.vms?.total ?? 0;
+  const totalClusters = Object.keys(aggregateView.clusters).length;
 
-  const totalVMs = vms?.total || 0;
-  const totalClusters = Object.keys(clusters).length;
-
-  // Build cluster view model
   const clusterView = buildClusterViewModel({
-    infra,
-    vms,
-    clusters,
+    infra: aggregateView.infra,
+    vms: aggregateView.vms,
+    clusters: aggregateView.clusters,
     selectedClusterId,
   });
 
@@ -476,6 +560,7 @@ export const ReportContainer: React.FC = () => {
       newParams = buildApplicationsTabUrl(searchParams);
     } else {
       newParams = buildOverviewTabUrl(searchParams);
+      void reloadAssessmentInventory();
     }
     setSearchParams(newParams, { replace: true });
   };
@@ -584,6 +669,7 @@ export const ReportContainer: React.FC = () => {
               <div style={{ marginTop: "24px" }}>
                 {clusterView.viewInfra && clusterView.viewVms ? (
                   <Dashboard
+                    key={`assessment-${inventoryRevision}-${clusterView.viewVms.total ?? 0}-${clusterView.selectionId}`}
                     infra={clusterView.viewInfra}
                     cpuCores={clusterView.cpuCores}
                     ramGB={clusterView.ramGB}
@@ -621,6 +707,7 @@ export const ReportContainer: React.FC = () => {
                   availableFilterOptions={availableFilterOptions}
                   agentApi={agentApi}
                   onRefreshVMs={refreshVMs}
+                  onRefreshInventory={refreshInventory}
                   showExcludedVMs={showExcludedVMs}
                   onShowExcludedVMsChange={(show) => {
                     setShowExcludedVMs(show);

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -6,6 +6,7 @@ import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { getAgentApiBasePath } from "../agentApiConfig";
+import type { MigrationExcludedInventoryChange } from "../inventoryParsing";
 import { AddLabelsModal } from "./AddLabelsModal";
 import { AddToGroupModal } from "./AddToGroupModal";
 import { CreateGroupFromSelectionModal } from "./CreateGroupFromSelectionModal";
@@ -28,7 +29,11 @@ async function updateVmMigrationExcluded(
   agentApi: DefaultApiInterface,
   vmIds: string[],
   migrationExcluded: boolean,
-  onRefreshVMs?: () => void,
+  knownVms: VirtualMachine[],
+  onRefreshVMs?: () => void | Promise<void>,
+  onRefreshInventory?: (
+    change: MigrationExcludedInventoryChange,
+  ) => void | Promise<void>,
 ): Promise<void> {
   const results = await Promise.allSettled(
     vmIds.map((id) =>
@@ -48,7 +53,17 @@ async function updateVmMigrationExcluded(
     }
   }
 
-  onRefreshVMs?.();
+  const successfulIds = vmIds.filter((id) => !failedIds.includes(id));
+  const affectedVms = knownVms.filter((vm) => successfulIds.includes(vm.id));
+
+  if (successfulIds.length > 0) {
+    await onRefreshInventory?.({
+      vmIds: successfulIds,
+      excluded: migrationExcluded,
+      affectedVms,
+    });
+  }
+  await onRefreshVMs?.();
 
   if (failedIds.length > 0) {
     throw new Error(
@@ -76,6 +91,10 @@ interface VirtualMachinesViewProps {
   };
   agentApi?: DefaultApiInterface;
   onRefreshVMs?: () => void;
+  /** Refresh assessment report inventory after exclude/include from migration. */
+  onRefreshInventory?: (
+    change: MigrationExcludedInventoryChange,
+  ) => void | Promise<void>;
   /** Reload group metadata/filter after add/remove (group detail page). */
   onGroupMembershipChanged?: () => void | Promise<void>;
   showExcludedVMs?: boolean;
@@ -100,6 +119,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   availableFilterOptions,
   agentApi,
   onRefreshVMs,
+  onRefreshInventory,
   onGroupMembershipChanged,
   showExcludedVMs,
   onShowExcludedVMsChange,
@@ -452,17 +472,31 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   const handleExcludeFromReports = useCallback(
     async (vmIds: string[]) => {
       if (!agentApi) return;
-      await updateVmMigrationExcluded(agentApi, vmIds, true, onRefreshVMs);
+      await updateVmMigrationExcluded(
+        agentApi,
+        vmIds,
+        true,
+        vmsForTable,
+        onRefreshVMs,
+        onRefreshInventory,
+      );
     },
-    [agentApi, onRefreshVMs],
+    [agentApi, onRefreshVMs, onRefreshInventory, vmsForTable],
   );
 
   const handleIncludeInReports = useCallback(
     async (vmIds: string[]) => {
       if (!agentApi) return;
-      await updateVmMigrationExcluded(agentApi, vmIds, false, onRefreshVMs);
+      await updateVmMigrationExcluded(
+        agentApi,
+        vmIds,
+        false,
+        vmsForTable,
+        onRefreshVMs,
+        onRefreshInventory,
+      );
     },
-    [agentApi, onRefreshVMs],
+    [agentApi, onRefreshVMs, onRefreshInventory, vmsForTable],
   );
 
   const handleResetInspection = useCallback(async () => {

--- a/apps/agent-ui/src/pages/Report/inventoryParsing.test.ts
+++ b/apps/agent-ui/src/pages/Report/inventoryParsing.test.ts
@@ -1,0 +1,141 @@
+import type {
+  Infra,
+  Inventory,
+  VirtualMachine,
+  VMs,
+} from "@openshift-migration-advisor/agent-sdk";
+import { describe, expect, it } from "vitest";
+import {
+  adjustInventoryForMigrationExcludedChange,
+  getInventoryAggregateView,
+  resolveInventoryAfterMigrationChange,
+} from "./inventoryParsing";
+
+const emptyResourceBreakdown = {
+  total: 0,
+  totalForMigratable: 0,
+  totalForMigratableWithWarnings: 0,
+  totalForNotMigratable: 0,
+} as const;
+
+const testInfra = (totalHosts: number): Infra => ({
+  totalHosts,
+  hostPowerStates: {},
+  networks: [],
+  datastores: [],
+});
+
+const testVms = (total: number, totalMigratable: number): VMs => ({
+  total,
+  totalMigratable,
+  cpuCores: emptyResourceBreakdown,
+  ramGB: emptyResourceBreakdown,
+  diskGB: emptyResourceBreakdown,
+  diskCount: emptyResourceBreakdown,
+  powerStates: {},
+  notMigratableReasons: [],
+  migrationWarnings: [],
+});
+
+const baseInventory: Inventory = {
+  vcenter_id: "vc-1",
+  clusters: {
+    "cluster-a": {
+      infra: testInfra(1),
+      vms: testVms(2, 1),
+    },
+  },
+  vcenter: {
+    infra: testInfra(1),
+    vms: testVms(2, 1),
+  },
+};
+
+const vm: VirtualMachine = {
+  id: "vm-1",
+  name: "web-1",
+  vCenterState: "poweredOn",
+  cluster: "cluster-a",
+  datacenter: "dc-1",
+  diskSize: 1024,
+  memory: 4096,
+  issueCount: 0,
+  migratable: true,
+  migrationExcluded: false,
+};
+
+describe("adjustInventoryForMigrationExcludedChange", () => {
+  it("decrements VM totals when excluding from reports", () => {
+    const updated = adjustInventoryForMigrationExcludedChange(
+      baseInventory,
+      ["vm-1"],
+      true,
+      [vm],
+    );
+
+    expect(getInventoryAggregateView(updated).vms?.total).toBe(1);
+    expect(updated.clusters["cluster-a"].vms?.total).toBe(1);
+  });
+
+  it("updates cluster aggregate totals when vcenter VMs are absent", () => {
+    const clusterOnlyInventory: Inventory = {
+      vcenter_id: "vc-1",
+      clusters: {
+        prod: {
+          infra: testInfra(2),
+          vms: testVms(5, 3),
+        },
+      },
+    };
+
+    const updated = adjustInventoryForMigrationExcludedChange(
+      clusterOnlyInventory,
+      ["vm-1"],
+      true,
+      [{ ...vm, cluster: "prod" }],
+    );
+
+    expect(getInventoryAggregateView(updated).vms?.total).toBe(4);
+    expect(updated.clusters.prod.vms?.total).toBe(4);
+  });
+});
+
+describe("getInventoryAggregateView", () => {
+  it("prefers vcenter VM totals even when vcenter infra is missing", () => {
+    const inventory: Inventory = {
+      vcenter_id: "vc-1",
+      clusters: {
+        prod: {
+          infra: testInfra(3),
+          vms: testVms(99, 50),
+        },
+      },
+      vcenter: {
+        infra: testInfra(1),
+        vms: testVms(10, 8),
+      },
+    };
+
+    expect(getInventoryAggregateView(inventory).vms?.total).toBe(10);
+  });
+});
+
+describe("resolveInventoryAfterMigrationChange", () => {
+  it("keeps optimistic inventory when server response is stale", () => {
+    const optimistic = adjustInventoryForMigrationExcludedChange(
+      baseInventory,
+      ["vm-1"],
+      true,
+      [vm],
+    );
+
+    const resolved = resolveInventoryAfterMigrationChange(
+      optimistic,
+      baseInventory,
+      { vmIds: ["vm-1"], excluded: true, affectedVms: [vm] },
+      2,
+    );
+
+    expect(getInventoryAggregateView(resolved).vms?.total).toBe(1);
+  });
+});

--- a/apps/agent-ui/src/pages/Report/inventoryParsing.ts
+++ b/apps/agent-ui/src/pages/Report/inventoryParsing.ts
@@ -3,25 +3,37 @@ import type {
   Infra,
   Inventory,
   InventoryData,
+  VirtualMachine,
   VMs,
 } from "@openshift-migration-advisor/agent-sdk";
 import {
   InventoryFromJSON,
   instanceOfInventory,
   instanceOfUpdateInventory,
+  UpdateInventoryFromJSON,
 } from "@openshift-migration-advisor/agent-sdk";
 
-/** Parse inventory JSON from GET /groups/{id} or GET /inventory. */
-export function parseInventoryFromJson(json: unknown): Inventory | null {
-  if (!json || typeof json !== "object") {
+export type MigrationExcludedInventoryChange = {
+  vmIds: string[];
+  excluded: boolean;
+  affectedVms: VirtualMachine[];
+};
+
+/** Parse inventory from GET /inventory (direct Inventory or UpdateInventory wrapper). */
+export function parseInventoryResponse(jsonData: unknown): Inventory | null {
+  if (!jsonData || typeof jsonData !== "object") {
     return null;
   }
-  const record = json as Record<string, unknown>;
+  const record = jsonData as Record<string, unknown>;
   if (Object.keys(record).length === 0) {
     return null;
   }
   if ("vcenter_id" in record && "clusters" in record) {
-    return InventoryFromJSON(json);
+    return InventoryFromJSON(jsonData);
+  }
+  if ("inventory" in record) {
+    const updateInventory = UpdateInventoryFromJSON(jsonData);
+    return updateInventory.inventory ?? null;
   }
   return null;
 }
@@ -45,6 +57,300 @@ export function inventoryFromGetInventoryResponse(
   return null;
 }
 
+/** Parse inventory JSON from GET /groups/{id} or GET /inventory. */
+export function parseInventoryFromJson(json: unknown): Inventory | null {
+  return parseInventoryResponse(json);
+}
+
+/** Fetch inventory from GET /inventory (bypasses SDK response parsing bug). */
+export async function fetchInventoryFromApi(
+  basePath: string,
+  options?: { groupId?: string },
+): Promise<Inventory | null> {
+  const url = new URL(`${basePath}/inventory`);
+  if (options?.groupId) {
+    url.searchParams.set("group_id", options.groupId);
+  }
+
+  const httpResponse = await fetch(url.toString(), { cache: "no-store" });
+  if (!httpResponse.ok) {
+    if (httpResponse.status === 404) {
+      return null;
+    }
+    throw new Error(`HTTP ${httpResponse.status}: ${httpResponse.statusText}`);
+  }
+
+  const jsonData = await httpResponse.json();
+  return parseInventoryResponse(jsonData);
+}
+
+function adjustVmsTotals(
+  vms: VMs,
+  totalDelta: number,
+  migratableDelta: number,
+): VMs {
+  return {
+    ...vms,
+    total: Math.max(0, (vms.total ?? 0) + totalDelta),
+    totalMigratable: Math.max(0, (vms.totalMigratable ?? 0) + migratableDelta),
+  };
+}
+
+function cloneInventory(inventory: Inventory): Inventory {
+  try {
+    return structuredClone(inventory);
+  } catch {
+    return JSON.parse(JSON.stringify(inventory)) as Inventory;
+  }
+}
+
+function findClusterKey(
+  clusters: Inventory["clusters"] | undefined,
+  clusterName: string,
+): string | undefined {
+  if (!clusters) {
+    return undefined;
+  }
+  if (clusterName in clusters) {
+    return clusterName;
+  }
+  const normalized = clusterName.toLowerCase();
+  return Object.keys(clusters).find((key) => key.toLowerCase() === normalized);
+}
+
+/** Write aggregate VM totals to the inventory location the dashboard reads. */
+function writeAggregateVms(inventory: Inventory, vms: VMs): Inventory {
+  if (inventory.vcenter?.vms) {
+    return {
+      ...inventory,
+      vcenter: {
+        ...inventory.vcenter,
+        vms,
+      },
+    };
+  }
+
+  const clusters = inventory.clusters ?? {};
+  const keys = Object.keys(clusters);
+  const clusterKey =
+    keys.find((key) => clusters[key]?.infra && clusters[key]?.vms) ?? keys[0];
+  if (!clusterKey || !clusters[clusterKey]?.vms) {
+    return inventory;
+  }
+
+  return {
+    ...inventory,
+    clusters: {
+      ...clusters,
+      [clusterKey]: {
+        ...clusters[clusterKey],
+        vms,
+      },
+    },
+  };
+}
+
+/**
+ * Optimistically adjust VM totals after exclude/include from reports.
+ * Keeps the assessment report in sync while the server recomputes inventory.
+ */
+export function adjustInventoryForMigrationExcludedChange(
+  inventory: Inventory,
+  vmIds: string[],
+  excluded: boolean,
+  knownVms: VirtualMachine[],
+): Inventory {
+  const sign = excluded ? -1 : 1;
+  let totalDelta = 0;
+  let migratableDelta = 0;
+  const clusterDeltas = new Map<
+    string,
+    { total: number; migratable: number }
+  >();
+
+  for (const id of vmIds) {
+    const vm = knownVms.find((candidate) => candidate.id === id);
+    if (vm?.migrationExcluded === excluded) {
+      continue;
+    }
+
+    totalDelta += sign;
+    if (vm?.migratable) {
+      migratableDelta += sign;
+    }
+
+    if (vm?.cluster) {
+      const current = clusterDeltas.get(vm.cluster) ?? {
+        total: 0,
+        migratable: 0,
+      };
+      current.total += sign;
+      if (vm.migratable) {
+        current.migratable += sign;
+      }
+      clusterDeltas.set(vm.cluster, current);
+    }
+  }
+
+  if (totalDelta === 0) {
+    return inventory;
+  }
+
+  let next = cloneInventory(inventory);
+  const aggregate = getInventoryAggregateView(next);
+  const aggregateClusterKey = !next.vcenter?.vms
+    ? (Object.keys(next.clusters ?? {}).find(
+        (key) => next.clusters[key]?.infra && next.clusters[key]?.vms,
+      ) ?? Object.keys(next.clusters ?? {})[0])
+    : undefined;
+
+  if (aggregate.vms) {
+    next = writeAggregateVms(
+      next,
+      adjustVmsTotals(aggregate.vms, totalDelta, migratableDelta),
+    );
+  }
+
+  for (const [clusterName, delta] of clusterDeltas) {
+    const clusterKey = findClusterKey(next.clusters, clusterName);
+    if (!clusterKey || !next.clusters?.[clusterKey]?.vms) {
+      continue;
+    }
+    if (!next.vcenter?.vms && clusterKey === aggregateClusterKey) {
+      continue;
+    }
+    next.clusters[clusterKey].vms = adjustVmsTotals(
+      next.clusters[clusterKey].vms,
+      delta.total,
+      delta.migratable,
+    );
+  }
+
+  return next;
+}
+
+function countMigrationExcludedDelta(
+  change: MigrationExcludedInventoryChange,
+): number {
+  const sign = change.excluded ? -1 : 1;
+  let count = 0;
+  for (const id of change.vmIds) {
+    const vm = change.affectedVms.find((candidate) => candidate.id === id);
+    if (!vm || vm.migrationExcluded !== change.excluded) {
+      count += 1;
+    }
+  }
+  return count * sign;
+}
+
+function getExpectedInventoryTotal(
+  previousTotal: number | undefined,
+  change: MigrationExcludedInventoryChange,
+): number | undefined {
+  if (previousTotal === undefined) {
+    return undefined;
+  }
+  const expectedDelta = countMigrationExcludedDelta(change);
+  if (expectedDelta === 0) {
+    return previousTotal;
+  }
+  return Math.max(0, previousTotal + expectedDelta);
+}
+
+/** Prefer server inventory when it reflects the change; otherwise keep optimistic state. */
+export function resolveInventoryAfterMigrationChange(
+  optimisticInventory: Inventory | null,
+  fetchedInventory: Inventory | null,
+  change: MigrationExcludedInventoryChange,
+  previousTotal: number | undefined,
+): Inventory | null {
+  if (!fetchedInventory) {
+    return optimisticInventory;
+  }
+  if (previousTotal === undefined) {
+    return optimisticInventory ?? fetchedInventory;
+  }
+
+  const fetchedTotal = getInventoryAggregateView(fetchedInventory).vms?.total;
+  const expectedDelta = countMigrationExcludedDelta(change);
+  const expectedTotal = Math.max(0, previousTotal + expectedDelta);
+
+  if (fetchedTotal === expectedTotal) {
+    return fetchedInventory;
+  }
+
+  // Server inventory can lag behind VM updates; keep the optimistic totals.
+  if (
+    expectedDelta < 0 &&
+    fetchedTotal !== undefined &&
+    fetchedTotal >= previousTotal
+  ) {
+    return optimisticInventory;
+  }
+  if (
+    expectedDelta > 0 &&
+    fetchedTotal !== undefined &&
+    fetchedTotal <= previousTotal
+  ) {
+    return optimisticInventory;
+  }
+
+  return fetchedInventory;
+}
+
+export async function fetchInventoryAfterMigrationChange(
+  basePath: string,
+  change: MigrationExcludedInventoryChange,
+  previousTotal: number | undefined,
+  optimisticInventory: Inventory | null,
+  options?: { groupId?: string; maxAttempts?: number },
+): Promise<Inventory | null> {
+  const expectedTotal = getExpectedInventoryTotal(previousTotal, change);
+  const maxAttempts = options?.maxAttempts ?? 8;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 400 * attempt));
+    }
+
+    const fetchedInventory = await fetchInventoryFromApi(basePath, options);
+    const resolved = resolveInventoryAfterMigrationChange(
+      optimisticInventory,
+      fetchedInventory,
+      change,
+      previousTotal,
+    );
+
+    if (expectedTotal === undefined) {
+      return resolved ?? optimisticInventory;
+    }
+
+    const resolvedTotal = getInventoryAggregateView(resolved).vms?.total;
+    if (resolvedTotal === expectedTotal) {
+      return resolved;
+    }
+  }
+
+  return optimisticInventory;
+}
+
+/** Keep optimistic totals when reloading inventory before the server catches up. */
+export function resolveInventoryOnReload(
+  currentInventory: Inventory,
+  fetchedInventory: Inventory,
+): Inventory {
+  const currentTotal = getInventoryAggregateView(currentInventory).vms?.total;
+  const fetchedTotal = getInventoryAggregateView(fetchedInventory).vms?.total;
+  if (
+    currentTotal !== undefined &&
+    fetchedTotal !== undefined &&
+    fetchedTotal !== currentTotal
+  ) {
+    return currentInventory;
+  }
+  return fetchedInventory;
+}
+
 export type InventoryAggregateView = {
   infra?: Infra;
   vms?: VMs;
@@ -59,7 +365,9 @@ export function getInventoryAggregateView(
   const vcenterInfra = inventory?.vcenter?.infra;
   const vcenterVms = inventory?.vcenter?.vms;
 
-  if (vcenterInfra && vcenterVms) {
+  // Prefer vcenter VM totals whenever present — this is what GET /inventory updates
+  // and what writeAggregateVms writes to after exclude/include.
+  if (vcenterVms) {
     return { infra: vcenterInfra, vms: vcenterVms, clusters };
   }
 

--- a/apps/agent-ui/src/pages/Report/virtualMachineParsing.test.ts
+++ b/apps/agent-ui/src/pages/Report/virtualMachineParsing.test.ts
@@ -1,0 +1,25 @@
+import type { VirtualMachine } from "@openshift-migration-advisor/agent-sdk";
+import { describe, expect, it } from "vitest";
+import { normalizeVirtualMachine } from "./virtualMachineParsing";
+
+const baseVm: VirtualMachine = {
+  id: "vm-1",
+  name: "web-1",
+  vCenterState: "poweredOn",
+  cluster: "cluster-a",
+  datacenter: "dc-1",
+  diskSize: 1024,
+  memory: 4096,
+  issueCount: 0,
+};
+
+describe("normalizeVirtualMachine", () => {
+  it("maps snake_case migration_excluded to migrationExcluded", () => {
+    const normalized = normalizeVirtualMachine({
+      ...baseVm,
+      migration_excluded: true,
+    } as VirtualMachine & { migration_excluded: boolean });
+
+    expect(normalized.migrationExcluded).toBe(true);
+  });
+});

--- a/apps/agent-ui/src/pages/Report/virtualMachineParsing.ts
+++ b/apps/agent-ui/src/pages/Report/virtualMachineParsing.ts
@@ -1,0 +1,21 @@
+import type { VirtualMachine } from "@openshift-migration-advisor/agent-sdk";
+
+type VirtualMachineJson = VirtualMachine & { migration_excluded?: boolean };
+
+/** Normalize VM JSON from GET /vms (handles snake_case migration_excluded). */
+export function normalizeVirtualMachine(vm: VirtualMachine): VirtualMachine {
+  const raw = vm as VirtualMachineJson;
+  if (
+    raw.migrationExcluded === undefined &&
+    raw.migration_excluded !== undefined
+  ) {
+    return { ...vm, migrationExcluded: raw.migration_excluded };
+  }
+  return vm;
+}
+
+export function normalizeVirtualMachines(
+  vms: VirtualMachine[] | undefined,
+): VirtualMachine[] {
+  return (vms ?? []).map(normalizeVirtualMachine);
+}


### PR DESCRIPTION
The fix is mainly optimistic inventory updates plus reading/writing the same aggregate VM totals (vcenter.vms on the main report), with polling and stale-data guards so server lag doesn’t undo the UI update.

[recording - 2026-06-09T120742.052.webm](https://github.com/user-attachments/assets/604b977a-23e3-4b97-a144-7e01ecf058bb)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimistic inventory updates when excluding/including VMs with automatic server reconciliation and forced dashboard refreshes.
  * VM exclusion/inclusion actions now trigger assessment inventory refreshes; switching to Overview also refreshes assessment data.
  * Assessment view remounts when inventory revisions change to show accurate totals.

* **Bug Fixes**
  * Improved VM data normalization for consistent migration-excluded handling and accurate totals.

* **Tests**
  * Added unit tests validating inventory reconciliation and VM normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->