### PR TITLE
ECOPROJECT-4677 | feat: presenting the running applications

### DIFF
--- a/apps/agent-ui/package.json
+++ b/apps/agent-ui/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@emotion/css": "^11.13.0",
     "@migration-planner-ui/ioc": "workspace:*",
-    "@openshift-migration-advisor/agent-sdk": "0.12.0-b4cc95d9b3d0",
+    "@openshift-migration-advisor/agent-sdk": "0.12.0-e4c04f972747",
     "@patternfly/react-charts": "^8.0.0",
     "@patternfly/react-core": "^6.4.3",
     "@patternfly/react-icons": "^6.4.0",

--- a/apps/agent-ui/src/pages/Report/GroupDetailPage.tsx
+++ b/apps/agent-ui/src/pages/Report/GroupDetailPage.tsx
@@ -2,8 +2,8 @@ import { useInjection } from "@migration-planner-ui/ioc";
 import {
   type DefaultApiInterface,
   type Group,
-  GroupFromJSON,
   type Inventory,
+  ResponseError,
   type VirtualMachine,
 } from "@openshift-migration-advisor/agent-sdk";
 import {
@@ -37,9 +37,8 @@ import {
 } from "react-router-dom";
 import { useAgentStatus } from "../../common/AgentStatusContext";
 import { Symbols } from "../../main/Symbols";
-import { getAgentApiBasePath } from "./agentApiConfig";
 import { buildClusterViewModel, type ClusterOption } from "./clusterView";
-import { Dashboard, VirtualMachinesView } from "./components";
+import { ApplicationsView, Dashboard, VirtualMachinesView } from "./components";
 import { DeleteGroupModal } from "./components/DeleteGroupModal";
 import { EditGroupNameModal } from "./components/EditGroupNameModal";
 import { combineFilterExpressions } from "./components/groupFilters";
@@ -49,10 +48,17 @@ import {
   searchParamsToFilters,
 } from "./components/vmFilters";
 import { Header } from "./Header";
+import { getInventoryAggregateView } from "./inventoryParsing";
 import {
-  getInventoryAggregateView,
-  parseInventoryFromJson,
-} from "./inventoryParsing";
+  buildApplicationsTabUrl,
+  buildOverviewTabUrl,
+  buildVmDetailUrl,
+  buildVmsTabUrl,
+  clearVmFilterParams,
+  REPORT_TAB,
+  resolveReportTab,
+} from "./reportTabNavigation";
+import { useApplicationsData } from "./useApplicationsData";
 
 export const GroupDetailPage: React.FC = () => {
   const { groupId } = useParams<{ groupId: string }>();
@@ -95,14 +101,31 @@ export const GroupDetailPage: React.FC = () => {
     [searchParams],
   );
 
-  const [activeTab, setActiveTab] = useState<string | number>(() => {
-    const tabParam = searchParams.get("tab");
-    if (tabParam === "vms") return 1;
-    if (hasActiveFilters(initialVMFilters)) return 1;
-    return 0;
-  });
+  const [activeTab, setActiveTab] = useState<string | number>(() =>
+    resolveReportTab(searchParams, hasActiveFilters(initialVMFilters)),
+  );
 
   const groupFilter = group?.filter;
+
+  const {
+    applications: applicationsList,
+    loading: applicationsLoading,
+    error: applicationsError,
+  } = useApplicationsData(
+    agentApi,
+    activeTab === REPORT_TAB.applications,
+    groupFilter,
+  );
+
+  useEffect(() => {
+    const nextTab = resolveReportTab(
+      searchParams,
+      hasActiveFilters(searchParamsToFilters(searchParams)),
+    );
+    if (nextTab !== activeTab) {
+      setActiveTab(nextTab);
+    }
+  }, [searchParams, activeTab]);
 
   useEffect(() => {
     if (!groupId) {
@@ -116,34 +139,24 @@ export const GroupDetailPage: React.FC = () => {
         setLoading(true);
         setError(null);
 
-        const basePath = getAgentApiBasePath(agentApi);
-        const httpResponse = await fetch(
-          `${basePath}/groups/${encodeURIComponent(groupId)}?page=1&pageSize=1`,
-          { cache: "no-store" },
-        );
+        const response = await agentApi.getGroup({
+          id: groupId,
+          page: 1,
+          pageSize: 1,
+        });
 
-        if (httpResponse.status === 404) {
-          setError("Group not found.");
-          return;
-        }
-        if (!httpResponse.ok) {
-          throw new Error(
-            `HTTP ${httpResponse.status}: ${httpResponse.statusText}`,
-          );
-        }
-
-        const jsonData = await httpResponse.json();
-        if (!jsonData?.group) {
-          setError("Group not found.");
-          return;
-        }
-
-        setGroup(GroupFromJSON(jsonData.group));
-        setVmsTotalCount(jsonData.total ?? 0);
-        setInventory(parseInventoryFromJson(jsonData.inventory));
+        setGroup(response.group);
+        setVmsTotalCount(response.total ?? 0);
+        setInventory(response.inventory ?? null);
       } catch (err) {
         console.error("Error loading group detail:", err);
-        setError(err instanceof Error ? err.message : "Failed to load group.");
+        if (err instanceof ResponseError && err.response?.status === 404) {
+          setError("Group not found.");
+        } else {
+          setError(
+            err instanceof Error ? err.message : "Failed to load group.",
+          );
+        }
       } finally {
         setLoading(false);
       }
@@ -153,7 +166,7 @@ export const GroupDetailPage: React.FC = () => {
   }, [agentApi, groupId]);
 
   useEffect(() => {
-    if (activeTab !== 1 || filterOptionsFetched) {
+    if (activeTab !== REPORT_TAB.vms || filterOptionsFetched) {
       return;
     }
 
@@ -181,7 +194,7 @@ export const GroupDetailPage: React.FC = () => {
   }, [activeTab, agentApi, filterOptionsFetched]);
 
   useEffect(() => {
-    if (activeTab !== 1 || !groupFilter) {
+    if (activeTab !== REPORT_TAB.vms || !groupFilter) {
       return;
     }
 
@@ -282,23 +295,14 @@ export const GroupDetailPage: React.FC = () => {
     }
 
     try {
-      const basePath = getAgentApiBasePath(agentApi);
-      const httpResponse = await fetch(
-        `${basePath}/groups/${encodeURIComponent(groupId)}?page=1&pageSize=1`,
-        { cache: "no-store" },
-      );
-      if (!httpResponse.ok) {
-        return;
-      }
-
-      const jsonData = await httpResponse.json();
-      if (!jsonData?.group) {
-        return;
-      }
-
-      setGroup(GroupFromJSON(jsonData.group));
-      setInventory(parseInventoryFromJson(jsonData.inventory));
-      setVmsTotalCount(jsonData.total ?? 0);
+      const response = await agentApi.getGroup({
+        id: groupId,
+        page: 1,
+        pageSize: 1,
+      });
+      setGroup(response.group);
+      setInventory(response.inventory ?? null);
+      setVmsTotalCount(response.total ?? 0);
       setVmsPage(1);
     } catch (err) {
       console.error("Error reloading group after membership change:", err);
@@ -310,14 +314,22 @@ export const GroupDetailPage: React.FC = () => {
     tabIndex: string | number,
   ) => {
     setActiveTab(tabIndex);
-    const newParams = new URLSearchParams(searchParams);
-    if (tabIndex === 1) {
-      newParams.set("tab", "vms");
+    let newParams: URLSearchParams;
+    if (tabIndex === REPORT_TAB.vms) {
+      newParams = buildVmsTabUrl(searchParams);
       setVmsPage(1);
+    } else if (tabIndex === REPORT_TAB.applications) {
+      newParams = buildApplicationsTabUrl(searchParams);
     } else {
-      newParams.set("tab", "overview");
+      newParams = buildOverviewTabUrl(searchParams);
     }
     setSearchParams(newParams, { replace: true });
+  };
+
+  const handleNavigateToVm = (vmId: string) => {
+    setActiveTab(REPORT_TAB.vms);
+    setSearchParams(buildVmDetailUrl(searchParams, vmId), { replace: true });
+    setVmsPage(1);
   };
 
   const handleClusterSelect = (
@@ -326,9 +338,11 @@ export const GroupDetailPage: React.FC = () => {
   ): void => {
     if (typeof value === "string") {
       setSelectedClusterId(value);
-      setActiveTab(0);
+      setActiveTab(REPORT_TAB.overview);
       const newParams = new URLSearchParams(searchParams);
       newParams.delete("tab");
+      newParams.delete("vmId");
+      clearVmFilterParams(newParams);
       setSearchParams(newParams, { replace: true });
     }
     setIsClusterSelectOpen(false);
@@ -499,7 +513,7 @@ export const GroupDetailPage: React.FC = () => {
         <StackItem>
           <Tabs activeKey={activeTab} onSelect={handleTabSelect}>
             <Tab
-              eventKey={0}
+              eventKey={REPORT_TAB.overview}
               title={<TabTitleText>Assessment report</TabTitleText>}
             >
               <div style={{ marginTop: "24px" }}>
@@ -531,7 +545,7 @@ export const GroupDetailPage: React.FC = () => {
               </div>
             </Tab>
             <Tab
-              eventKey={1}
+              eventKey={REPORT_TAB.vms}
               title={<TabTitleText>Virtual machines</TabTitleText>}
             >
               <div style={{ marginTop: "24px" }}>
@@ -560,6 +574,19 @@ export const GroupDetailPage: React.FC = () => {
                   groupContext={{ id: group.id, name: group.name }}
                   scopedFilterExpression={group.filter}
                   sortFields={vmsSortFields}
+                />
+              </div>
+            </Tab>
+            <Tab
+              eventKey={REPORT_TAB.applications}
+              title={<TabTitleText>Applications</TabTitleText>}
+            >
+              <div style={{ marginTop: "24px" }}>
+                <ApplicationsView
+                  applications={applicationsList}
+                  loading={applicationsLoading}
+                  error={applicationsError}
+                  onNavigateToVm={handleNavigateToVm}
                 />
               </div>
             </Tab>

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -6,9 +6,9 @@ import type {
   VirtualMachine,
 } from "@openshift-migration-advisor/agent-sdk";
 import {
-  InventoryFromJSON,
+  instanceOfInventory,
+  instanceOfUpdateInventory,
   ResponseError,
-  UpdateInventoryFromJSON,
 } from "@openshift-migration-advisor/agent-sdk";
 import {
   Alert,
@@ -34,9 +34,12 @@ import {
   DataSharingModal,
 } from "../../common/components/index";
 import { Symbols } from "../../main/Symbols";
-import { getAgentApiBasePath } from "./agentApiConfig";
 import { buildClusterViewModel, type ClusterOption } from "./clusterView";
-import { Dashboard, VirtualMachinesView } from "./components/index";
+import {
+  ApplicationsView,
+  Dashboard,
+  VirtualMachinesView,
+} from "./components/index";
 import { VMUtilizationMetrics } from "./components/VMUtilizationMetrics";
 import {
   filtersToByExpression,
@@ -44,6 +47,17 @@ import {
   searchParamsToFilters,
 } from "./components/vmFilters";
 import { Header } from "./Header";
+import { inventoryFromGetInventoryResponse } from "./inventoryParsing";
+import {
+  buildApplicationsTabUrl,
+  buildOverviewTabUrl,
+  buildVmDetailUrl,
+  buildVmsTabUrl,
+  clearVmFilterParams,
+  REPORT_TAB,
+  resolveReportTab,
+} from "./reportTabNavigation";
+import { useApplicationsData } from "./useApplicationsData";
 
 export const ReportContainer: React.FC = () => {
   const agentApi = useInjection<DefaultApiInterface>(Symbols.AgentApi);
@@ -91,40 +105,29 @@ export const ReportContainer: React.FC = () => {
   });
   const [filterOptionsFetched, setFilterOptionsFetched] = useState(false);
 
-  // Parse filters from URL (recalculates when URL changes)
   const initialVMFilters = useMemo(
     () => searchParamsToFilters(searchParams),
     [searchParams],
   );
 
   // Determine initial tab based on URL params (only on mount)
-  const [activeTab, setActiveTab] = useState<string | number>(() => {
-    const tabParam = searchParams.get("tab");
-    if (tabParam === "vms") return 1;
-    if (tabParam === "storage-offload") return 2;
-    // If there are VM filters in URL, open Virtual Machines tab
-    if (hasActiveFilters(initialVMFilters)) return 1;
-    return 0;
-  });
+  const [activeTab, setActiveTab] = useState<string | number>(() =>
+    resolveReportTab(searchParams, hasActiveFilters(initialVMFilters)),
+  );
 
-  // Sync active tab with URL changes
+  const {
+    applications: applicationsList,
+    loading: applicationsLoading,
+    error: applicationsError,
+  } = useApplicationsData(agentApi, activeTab === REPORT_TAB.applications);
+
   useEffect(() => {
-    const tabParam = searchParams.get("tab");
-    if (tabParam === "vms" && activeTab !== 1) {
-      setActiveTab(1);
-    } else if (tabParam === "storage-offload" && activeTab !== 2) {
-      setActiveTab(2);
-    } else if ((tabParam === "overview" || !tabParam) && activeTab !== 0) {
-      // Switch to overview if tab is explicitly "overview" or no tab param
-      // Only check for VM filters if no tab param is set (legacy behavior)
-      if (tabParam === "overview") {
-        setActiveTab(0);
-      } else if (!tabParam) {
-        const currentFilters = searchParamsToFilters(searchParams);
-        if (!hasActiveFilters(currentFilters)) {
-          setActiveTab(0);
-        }
-      }
+    const nextTab = resolveReportTab(
+      searchParams,
+      hasActiveFilters(searchParamsToFilters(searchParams)),
+    );
+    if (nextTab !== activeTab) {
+      setActiveTab(nextTab);
     }
   }, [searchParams, activeTab]);
 
@@ -133,56 +136,11 @@ export const ReportContainer: React.FC = () => {
     const fetchData = async () => {
       try {
         setLoading(true);
-
-        // Workaround: Fetch directly with native fetch API to bypass SDK bug
-        // The published SDK has a bug where GetInventory200ResponseFromJSONTyped returns {}
-        // when it receives snake_case JSON from the API
-        const basePath = getAgentApiBasePath(agentApi);
-
-        const httpResponse = await fetch(`${basePath}/inventory`);
-
-        if (!httpResponse.ok) {
-          throw new Error(
-            `HTTP ${httpResponse.status}: ${httpResponse.statusText}`,
-          );
-        }
-
-        const jsonData = await httpResponse.json();
-
-        if (!jsonData) {
-          setInventory(null);
-          return;
-        }
-
-        // Check if response is an empty object - means inventory not collected yet
-        if (
-          typeof jsonData === "object" &&
-          Object.keys(jsonData).length === 0
-        ) {
-          setInventory(null);
-          return;
-        }
-
-        // Manually parse the JSON using the SDK converters
-        let actualInventory: Inventory | null = null;
-
-        // Check raw JSON structure (before SDK conversion)
-        if ("vcenter_id" in jsonData && "clusters" in jsonData) {
-          // It's an Inventory - parse it manually
-          actualInventory = InventoryFromJSON(jsonData);
-        } else if ("inventory" in jsonData) {
-          // It's UpdateInventory - parse and extract
-          const updateInventory = UpdateInventoryFromJSON(jsonData);
-          if (updateInventory.inventory) {
-            actualInventory = updateInventory.inventory;
-          }
-        }
-
-        setInventory(actualInventory);
+        const response = await agentApi.getInventory({});
+        setInventory(inventoryFromGetInventoryResponse(response));
       } catch (err) {
         console.error("Error fetching inventory:", err);
 
-        // Handle 404 specifically - inventory not collected yet
         if (err instanceof ResponseError && err.response?.status === 404) {
           setInventory(null);
           setError(null);
@@ -236,7 +194,7 @@ export const ReportContainer: React.FC = () => {
 
   // Fetch available filter options once when VMs tab is first accessed
   useEffect(() => {
-    if (activeTab !== 1) return;
+    if (activeTab !== REPORT_TAB.vms) return;
     if (filterOptionsFetched) return;
     if (!inventory) return;
 
@@ -267,7 +225,7 @@ export const ReportContainer: React.FC = () => {
 
   // Fetch VMs when Virtual Machines tab is active or filters change
   useEffect(() => {
-    if (activeTab !== 1) return;
+    if (activeTab !== REPORT_TAB.vms) return;
 
     const fetchVMs = async () => {
       vmsRequestIdRef.current += 1;
@@ -451,29 +409,13 @@ export const ReportContainer: React.FC = () => {
 
   const handleDownloadInventory = async () => {
     try {
-      // Workaround: Fetch directly to bypass SDK bug (same as in the main fetch)
-      const basePath = getAgentApiBasePath(agentApi);
+      const response = await agentApi.getInventory({ withAgentId: true });
 
-      const httpResponse = await fetch(
-        `${basePath}/inventory?withAgentId=true`,
-      );
-
-      if (!httpResponse.ok) {
-        throw new Error(
-          `HTTP ${httpResponse.status}: ${httpResponse.statusText}`,
-        );
-      }
-
-      const jsonData = await httpResponse.json();
-
-      // Ensure the downloaded JSON is in UpdateInventory format
-      // The API may return a plain Inventory (with vcenter_id at top level)
-      // or an UpdateInventory wrapper ({ agent_id: "...", inventory: {...} })
-      let downloadData = jsonData;
-      if (jsonData && !("inventory" in jsonData) && "vcenter_id" in jsonData) {
-        const agentId = jsonData.agent_id || jsonData.agentId || "";
-        delete jsonData.agent_id;
-        downloadData = { agent_id: agentId, inventory: jsonData };
+      let downloadData: unknown = response;
+      if (instanceOfInventory(response)) {
+        downloadData = { agent_id: "", inventory: response };
+      } else if (!instanceOfUpdateInventory(response)) {
+        throw new Error("Unexpected inventory response format");
       }
 
       const jsonString = JSON.stringify(downloadData, null, 2);
@@ -511,26 +453,11 @@ export const ReportContainer: React.FC = () => {
   ): void => {
     if (typeof value === "string") {
       setSelectedClusterId(value);
-      // Reset to Overview tab when changing cluster
-      setActiveTab(0);
-      // Update URL to reflect tab change and clear all VM filters
+      setActiveTab(REPORT_TAB.overview);
       const newParams = new URLSearchParams(searchParams);
       newParams.delete("tab");
-      // Clear all VM filter keys (same as handleTabSelect does)
-      newParams.delete("statuses");
-      newParams.delete("hasIssues");
-      newParams.delete("noIssues");
-      newParams.delete("clusters");
-      newParams.delete("datacenters");
-      newParams.delete("search");
-      newParams.delete("diskRangeMin");
-      newParams.delete("diskRangeMax");
-      newParams.delete("memoryRangeMin");
-      newParams.delete("memoryRangeMax");
-      newParams.delete("migrationReadiness");
-      newParams.delete("vmLabels");
-      newParams.delete("concernLabels");
-      newParams.delete("concernCategories");
+      newParams.delete("vmId");
+      clearVmFilterParams(newParams);
       setSearchParams(newParams, { replace: true });
     }
     setIsClusterSelectOpen(false);
@@ -541,48 +468,22 @@ export const ReportContainer: React.FC = () => {
     tabIndex: string | number,
   ) => {
     setActiveTab(tabIndex);
-    // Update URL with tab parameter
-    const newParams = new URLSearchParams(searchParams);
-    if (tabIndex === 1) {
-      newParams.set("tab", "vms");
-      // Reset pagination when switching to VMs tab
+    let newParams: URLSearchParams;
+    if (tabIndex === REPORT_TAB.vms) {
+      newParams = buildVmsTabUrl(searchParams);
       setVmsPage(1);
-    } else if (tabIndex === 2) {
-      newParams.set("tab", "storage-offload");
-      // Clear all VM filters when switching to storage offload tab
-      newParams.delete("statuses");
-      newParams.delete("hasIssues");
-      newParams.delete("noIssues");
-      newParams.delete("clusters");
-      newParams.delete("datacenters");
-      newParams.delete("search");
-      newParams.delete("diskRangeMin");
-      newParams.delete("diskRangeMax");
-      newParams.delete("memoryRangeMin");
-      newParams.delete("memoryRangeMax");
-      newParams.delete("migrationReadiness");
-      newParams.delete("vmLabels");
-      newParams.delete("concernLabels");
-      newParams.delete("concernCategories");
+    } else if (tabIndex === REPORT_TAB.applications) {
+      newParams = buildApplicationsTabUrl(searchParams);
     } else {
-      newParams.set("tab", "overview");
-      // Clear all VM filters when switching away from VMs tab
-      newParams.delete("statuses");
-      newParams.delete("hasIssues");
-      newParams.delete("noIssues");
-      newParams.delete("clusters");
-      newParams.delete("datacenters");
-      newParams.delete("search");
-      newParams.delete("diskRangeMin");
-      newParams.delete("diskRangeMax");
-      newParams.delete("memoryRangeMin");
-      newParams.delete("memoryRangeMax");
-      newParams.delete("migrationReadiness");
-      newParams.delete("vmLabels");
-      newParams.delete("concernLabels");
-      newParams.delete("concernCategories");
+      newParams = buildOverviewTabUrl(searchParams);
     }
     setSearchParams(newParams, { replace: true });
+  };
+
+  const handleNavigateToVm = (vmId: string) => {
+    setActiveTab(REPORT_TAB.vms);
+    setSearchParams(buildVmDetailUrl(searchParams, vmId), { replace: true });
+    setVmsPage(1);
   };
 
   const handleFiltersChange = () => {
@@ -601,16 +502,10 @@ export const ReportContainer: React.FC = () => {
   };
 
   const handleConcernClick = (concernLabel: string) => {
-    // Switch to VMs tab and apply concern filter
-    setActiveTab(1);
-
-    // Update URL with concern filter
-    const newParams = new URLSearchParams(searchParams);
-    newParams.set("tab", "vms");
+    setActiveTab(REPORT_TAB.vms);
+    const newParams = buildVmsTabUrl(searchParams);
     newParams.set("concernLabels", concernLabel);
     setSearchParams(newParams, { replace: true });
-
-    // Reset pagination
     setVmsPage(1);
   };
 
@@ -683,7 +578,7 @@ export const ReportContainer: React.FC = () => {
         <StackItem>
           <Tabs activeKey={activeTab} onSelect={handleTabSelect}>
             <Tab
-              eventKey={0}
+              eventKey={REPORT_TAB.overview}
               title={<TabTitleText>Assessment report</TabTitleText>}
             >
               <div style={{ marginTop: "24px" }}>
@@ -708,7 +603,7 @@ export const ReportContainer: React.FC = () => {
               </div>
             </Tab>
             <Tab
-              eventKey={1}
+              eventKey={REPORT_TAB.vms}
               title={<TabTitleText>Virtual Machines</TabTitleText>}
             >
               <div style={{ marginTop: "24px" }}>
@@ -731,6 +626,19 @@ export const ReportContainer: React.FC = () => {
                     setShowExcludedVMs(show);
                     setVmsPage(1);
                   }}
+                />
+              </div>
+            </Tab>
+            <Tab
+              eventKey={REPORT_TAB.applications}
+              title={<TabTitleText>Applications</TabTitleText>}
+            >
+              <div style={{ marginTop: "24px" }}>
+                <ApplicationsView
+                  applications={applicationsList}
+                  loading={applicationsLoading}
+                  error={applicationsError}
+                  onNavigateToVm={handleNavigateToVm}
                 />
               </div>
             </Tab>

--- a/apps/agent-ui/src/pages/Report/components/ApplicationsView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ApplicationsView.tsx
@@ -1,0 +1,388 @@
+import { css } from "@emotion/css";
+import {
+  Alert,
+  Bullseye,
+  Button,
+  Checkbox,
+  Drawer,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerHead,
+  DrawerPanelBody,
+  DrawerPanelContent,
+  Dropdown,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Label,
+  LabelGroup,
+  MenuToggle,
+  type MenuToggleElement,
+  Pagination,
+  SearchInput,
+  Title,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from "@patternfly/react-core";
+import { FilterIcon, SearchIcon } from "@patternfly/react-icons";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
+import type React from "react";
+import { useMemo, useState } from "react";
+import {
+  buildVmLookup,
+  filterApplications,
+  filterVmsBySearch,
+  getUniqueVms,
+  getVmFilterLabel,
+  paginateItems,
+} from "./applicationFilters";
+import type { ApplicationOverview } from "./applicationsApi";
+
+const styles = {
+  drawerPanel: css`
+    min-width: 320px;
+  `,
+  vmList: css`
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  `,
+  toolbar: css`
+    margin-bottom: 16px;
+  `,
+  appliedFilters: css`
+    margin-bottom: 16px;
+  `,
+  vmFilterMenu: css`
+    padding: 8px 16px 0;
+  `,
+  vmFilterList: css`
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 8px 16px 16px;
+    max-height: 300px;
+    overflow-y: auto;
+  `,
+  vmFilterEmpty: css`
+    padding: 8px 16px 16px;
+    color: var(--pf-t--global--text--color--subtle);
+  `,
+};
+
+interface ApplicationsViewProps {
+  applications: ApplicationOverview[];
+  loading?: boolean;
+  error?: string | null;
+  onNavigateToVm?: (vmId: string) => void;
+}
+
+export const ApplicationsView: React.FC<ApplicationsViewProps> = ({
+  applications,
+  loading = false,
+  error = null,
+  onNavigateToVm,
+}) => {
+  const [nameSearch, setNameSearch] = useState("");
+  const [selectedVmIds, setSelectedVmIds] = useState<string[]>([]);
+  const [isVmFilterOpen, setIsVmFilterOpen] = useState(false);
+  const [vmFilterSearch, setVmFilterSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [drawerApplication, setDrawerApplication] =
+    useState<ApplicationOverview | null>(null);
+  const [drawerVmSearch, setDrawerVmSearch] = useState("");
+
+  const vmById = useMemo(() => buildVmLookup(applications), [applications]);
+  const allVms = useMemo(() => getUniqueVms(applications), [applications]);
+
+  const filteredVmOptions = useMemo(
+    () => filterVmsBySearch(allVms, vmFilterSearch),
+    [allVms, vmFilterSearch],
+  );
+
+  const filteredApplications = useMemo(
+    () =>
+      filterApplications(applications, {
+        nameSearch,
+        vmIds: selectedVmIds,
+      }),
+    [applications, nameSearch, selectedVmIds],
+  );
+
+  const paginatedApplications = useMemo(
+    () => paginateItems(filteredApplications, page, pageSize),
+    [filteredApplications, page, pageSize],
+  );
+
+  const drawerVms = useMemo(() => {
+    if (!drawerApplication) {
+      return [];
+    }
+    return filterVmsBySearch(drawerApplication.vms, drawerVmSearch);
+  }, [drawerApplication, drawerVmSearch]);
+
+  const trimmedNameSearch = nameSearch.trim();
+  const hasActiveFilters =
+    trimmedNameSearch.length > 0 || selectedVmIds.length > 0;
+  const vmFilterLabel = getVmFilterLabel(selectedVmIds, vmById);
+
+  const resetPage = () => setPage(1);
+
+  const closeDrawer = () => {
+    setDrawerApplication(null);
+    setDrawerVmSearch("");
+  };
+
+  const openDrawer = (application: ApplicationOverview) => {
+    setDrawerApplication(application);
+    setDrawerVmSearch("");
+  };
+
+  const applyNameSearch = (value: string) => {
+    closeDrawer();
+    setNameSearch(value);
+    resetPage();
+  };
+
+  const toggleVmFilter = (vmId: string) => {
+    closeDrawer();
+    setSelectedVmIds((prev) =>
+      prev.includes(vmId) ? prev.filter((id) => id !== vmId) : [...prev, vmId],
+    );
+    resetPage();
+  };
+
+  const clearAllFilters = () => {
+    closeDrawer();
+    setNameSearch("");
+    setSelectedVmIds([]);
+    resetPage();
+  };
+
+  const removeVmFilter = (vmId: string) => {
+    closeDrawer();
+    setSelectedVmIds((prev) => prev.filter((id) => id !== vmId));
+    resetPage();
+  };
+
+  const panelContent = drawerApplication ? (
+    <DrawerPanelContent className={styles.drawerPanel}>
+      <DrawerHead>
+        <Title headingLevel="h2" size="xl">
+          VMs with {drawerApplication.name}
+        </Title>
+        <DrawerActions>
+          <DrawerCloseButton onClick={closeDrawer} />
+        </DrawerActions>
+      </DrawerHead>
+      <DrawerPanelBody>
+        <SearchInput
+          placeholder="Find by virtual machine name"
+          value={drawerVmSearch}
+          onChange={(_event, value) => setDrawerVmSearch(value)}
+          onClear={() => setDrawerVmSearch("")}
+          style={{ marginBottom: "16px" }}
+        />
+        {drawerVms.length === 0 ? (
+          <Bullseye style={{ padding: "32px 0" }}>
+            <EmptyState
+              headingLevel="h3"
+              titleText="No virtual machines match this search criteria"
+              icon={SearchIcon}
+              variant={EmptyStateVariant.sm}
+            >
+              <EmptyStateBody>
+                Try a different search term or clear the search field.
+              </EmptyStateBody>
+            </EmptyState>
+          </Bullseye>
+        ) : (
+          <div className={styles.vmList}>
+            {drawerVms.map((vm) => (
+              <Button
+                key={vm.id}
+                variant="link"
+                isInline
+                onClick={() => onNavigateToVm?.(vm.id)}
+              >
+                {vm.name}
+              </Button>
+            ))}
+          </div>
+        )}
+      </DrawerPanelBody>
+    </DrawerPanelContent>
+  ) : null;
+
+  return (
+    <Drawer isExpanded={drawerApplication !== null} isInline position="end">
+      <DrawerContent panelContent={panelContent}>
+        <DrawerContentBody>
+          {error && (
+            <Alert
+              variant="danger"
+              title="Error loading applications"
+              style={{ marginBottom: "16px" }}
+            >
+              {error}
+            </Alert>
+          )}
+
+          <Toolbar className={styles.toolbar}>
+            <ToolbarContent>
+              <ToolbarGroup variant="filter-group">
+                <ToolbarItem>
+                  <SearchInput
+                    placeholder="Find by application name"
+                    value={nameSearch}
+                    onChange={(_event, value) => applyNameSearch(value)}
+                    onClear={() => applyNameSearch("")}
+                  />
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Dropdown
+                    isOpen={isVmFilterOpen}
+                    onOpenChange={(open) => {
+                      setIsVmFilterOpen(open);
+                      if (!open) {
+                        setVmFilterSearch("");
+                      }
+                    }}
+                    isScrollable
+                    maxMenuHeight="360px"
+                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                      <MenuToggle
+                        ref={toggleRef}
+                        onClick={() => setIsVmFilterOpen((open) => !open)}
+                        isExpanded={isVmFilterOpen}
+                        icon={<FilterIcon />}
+                      >
+                        {vmFilterLabel}
+                      </MenuToggle>
+                    )}
+                  >
+                    <div className={styles.vmFilterMenu}>
+                      <SearchInput
+                        placeholder="Type to filter VMs"
+                        value={vmFilterSearch}
+                        onChange={(_event, value) => setVmFilterSearch(value)}
+                        onClear={() => setVmFilterSearch("")}
+                      />
+                    </div>
+                    {filteredVmOptions.length === 0 ? (
+                      <div className={styles.vmFilterEmpty}>
+                        No virtual machines available
+                      </div>
+                    ) : (
+                      <div className={styles.vmFilterList}>
+                        {filteredVmOptions.map((vm) => (
+                          <Checkbox
+                            key={vm.id}
+                            id={`applications-vm-filter-${vm.id}`}
+                            label={vm.name}
+                            isChecked={selectedVmIds.includes(vm.id)}
+                            onChange={() => toggleVmFilter(vm.id)}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </Dropdown>
+                </ToolbarItem>
+              </ToolbarGroup>
+              <ToolbarItem align={{ default: "alignEnd" }}>
+                <Pagination
+                  itemCount={filteredApplications.length}
+                  perPage={pageSize}
+                  page={page}
+                  onSetPage={(_event, newPage) => setPage(newPage)}
+                  onPerPageSelect={(_event, newPerPage) => {
+                    setPage(1);
+                    setPageSize(newPerPage);
+                  }}
+                  variant="top"
+                  isCompact
+                />
+              </ToolbarItem>
+            </ToolbarContent>
+          </Toolbar>
+
+          {hasActiveFilters && (
+            <Toolbar className={styles.appliedFilters}>
+              <ToolbarContent alignItems="center">
+                <ToolbarItem>
+                  <LabelGroup>
+                    {trimmedNameSearch && (
+                      <Label color="blue" onClose={() => applyNameSearch("")}>
+                        {trimmedNameSearch}
+                      </Label>
+                    )}
+                    {selectedVmIds.map((vmId) => (
+                      <Label
+                        key={vmId}
+                        color="blue"
+                        onClose={() => removeVmFilter(vmId)}
+                      >
+                        {vmById.get(vmId)?.name ?? vmId}
+                      </Label>
+                    ))}
+                  </LabelGroup>
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Button variant="link" onClick={clearAllFilters}>
+                    Clear all filters
+                  </Button>
+                </ToolbarItem>
+              </ToolbarContent>
+            </Toolbar>
+          )}
+
+          <Table aria-label="Applications" variant="compact">
+            <Thead>
+              <Tr>
+                <Th>Application name</Th>
+                <Th>VMs</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {loading ? (
+                <Tr>
+                  <Td colSpan={2}>Loading applications...</Td>
+                </Tr>
+              ) : filteredApplications.length === 0 ? (
+                <Tr>
+                  <Td colSpan={2}>
+                    {applications.length === 0
+                      ? "No applications were detected on your virtual machines."
+                      : "No applications match the current filters."}
+                  </Td>
+                </Tr>
+              ) : (
+                paginatedApplications.map((application) => (
+                  <Tr key={application.name}>
+                    <Td dataLabel="Application name">{application.name}</Td>
+                    <Td dataLabel="VMs">
+                      <Button
+                        variant="link"
+                        isInline
+                        onClick={() => openDrawer(application)}
+                      >
+                        {application.vmCount}
+                      </Button>
+                    </Td>
+                  </Tr>
+                ))
+              )}
+            </Tbody>
+          </Table>
+        </DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+ApplicationsView.displayName = "ApplicationsView";

--- a/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ManageLabelsModal.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/css";
+import type { DefaultApiInterface } from "@openshift-migration-advisor/agent-sdk";
 import {
   Button,
   Content,
@@ -84,14 +85,14 @@ interface ManageLabelsModalProps {
   isOpen: boolean;
   onClose: () => void;
   onLabelsChanged: () => void;
-  basePath: string;
+  agentApi: DefaultApiInterface;
 }
 
 export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
   isOpen,
   onClose,
   onLabelsChanged,
-  basePath,
+  agentApi,
 }) => {
   const [labels, setLabels] = useState<LabelInfo[]>([]);
   const [loading, setLoading] = useState(false);
@@ -106,19 +107,11 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
   const fetchLabelsWithCounts = useCallback(async () => {
     setLoading(true);
     try {
-      const labelsResponse = await fetch(`${basePath}/vms/labels`);
-      if (!labelsResponse.ok) {
-        setLabels([]);
-        return;
-      }
-      const labelsData = await labelsResponse.json();
-      const labelNames: string[] = labelsData.labels || [];
-      const labelCounts: number[] = labelsData.counts || [];
-
+      const data = await agentApi.getVMLabels();
       setLabels(
-        labelNames.map((name, i) => ({
+        (data.labels ?? []).map((name, i) => ({
           name,
-          vmCount: labelCounts[i] || 0,
+          vmCount: data.counts?.[i] ?? 0,
         })),
       );
     } catch (err) {
@@ -127,7 +120,7 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
     } finally {
       setLoading(false);
     }
-  }, [basePath]);
+  }, [agentApi]);
 
   useEffect(() => {
     if (isOpen) {
@@ -194,9 +187,7 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
     setIsSaving(true);
     try {
       for (const labelName of pendingDeletes.current) {
-        await fetch(`${basePath}/vms/labels/${encodeURIComponent(labelName)}`, {
-          method: "DELETE",
-        });
+        await agentApi.deleteLabelGlobally({ label: labelName });
       }
 
       for (const { oldName, newName } of pendingRenames.current) {
@@ -204,33 +195,25 @@ export const ManageLabelsModal: React.FC<ManageLabelsModalProps> = ({
         let page = 1;
         let hasMore = true;
         while (hasMore) {
-          const vmsResponse = await fetch(
-            `${basePath}/vms?page=${page}&pageSize=1000`,
-          );
-          if (!vmsResponse.ok) break;
-          const vmsData = await vmsResponse.json();
-          const vms: { id: string; labels?: string[] }[] = vmsData.vms || [];
-          for (const vm of vms) {
+          const vmsData = await agentApi.getVMs({ page, pageSize: 1000 });
+          for (const vm of vmsData.vms ?? []) {
             if (vm.labels?.includes(oldName)) {
               vmIds.push(vm.id);
             }
           }
-          const total = vmsData.total || 0;
+          const total = vmsData.total ?? 0;
           hasMore = page * 1000 < total;
           page++;
         }
 
         if (vmIds.length > 0) {
-          await fetch(`${basePath}/vms/labels/${encodeURIComponent(newName)}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ add: vmIds }),
+          await agentApi.updateLabelVMs({
+            label: newName,
+            updateLabelVMsRequest: { add: vmIds },
           });
         }
 
-        await fetch(`${basePath}/vms/labels/${encodeURIComponent(oldName)}`, {
-          method: "DELETE",
-        });
+        await agentApi.deleteLabelGlobally({ label: oldName });
       }
 
       pendingDeletes.current = [];

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -4,6 +4,7 @@ import type {
 } from "@openshift-migration-advisor/agent-sdk";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { getAgentApiBasePath } from "../agentApiConfig";
 import { AddLabelsModal } from "./AddLabelsModal";
 import { AddToGroupModal } from "./AddToGroupModal";
@@ -106,6 +107,7 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   scopedFilterExpression,
   sortFields = [],
 }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
   const variant = groupContext ? "groups" : "overview";
   const [selectedVMId, setSelectedVMId] = useState<string | null>(null);
   const [selectedVMs, setSelectedVMs] = useState<Set<string>>(new Set());
@@ -139,6 +141,14 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
     onRefreshVMsRef.current = onRefreshVMs;
   }, [onRefreshVMs]);
 
+  const vmIdParam = searchParams.get("vmId");
+
+  useEffect(() => {
+    if (vmIdParam) {
+      setSelectedVMId(vmIdParam);
+    }
+  }, [vmIdParam]);
+
   // Labels state
   const [isAddLabelsModalOpen, setIsAddLabelsModalOpen] = useState(false);
   const [addLabelsMode, setAddLabelsMode] = useState<"add" | "edit">("add");
@@ -156,7 +166,10 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
       groupsByName: {},
     });
 
-  const basePath = useMemo(() => getAgentApiBasePath(agentApi), [agentApi]);
+  const basePath = useMemo(
+    () => (agentApi ? getAgentApiBasePath(agentApi) : ""),
+    [agentApi],
+  );
 
   const loadVmGroupMembership = useCallback(async () => {
     if (!agentApi) {
@@ -187,16 +200,16 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
   }, [showExcludedVMs, vmsForTable]);
 
   const fetchAvailableLabels = useCallback(async () => {
+    if (!agentApi) {
+      return;
+    }
     try {
-      const response = await fetch(`${basePath}/vms/labels`);
-      if (response.ok) {
-        const data = await response.json();
-        setAvailableLabels(data.labels || []);
-      }
+      const data = await agentApi.getVMLabels();
+      setAvailableLabels(data.labels ?? []);
     } catch (err) {
       console.error("Error fetching labels:", err);
     }
-  }, [basePath]);
+  }, [agentApi]);
 
   useEffect(() => {
     void fetchAvailableLabels();
@@ -328,36 +341,29 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
 
   const handleSubmitLabels = useCallback(
     async (labelsToAdd: string[], labelsToRemove: string[]) => {
+      if (!agentApi) {
+        return;
+      }
       const vmIds = addLabelsVMIds;
 
       const addPromises = labelsToAdd.map((label) =>
-        fetch(`${basePath}/vms/labels/${encodeURIComponent(label)}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ add: vmIds }),
-        }).then((res) => {
-          if (!res.ok) {
-            throw new Error(`Failed to add label "${label}": ${res.status}`);
-          }
+        agentApi.updateLabelVMs({
+          label,
+          updateLabelVMsRequest: { add: vmIds },
         }),
       );
 
       const removePromises = labelsToRemove.map((label) =>
-        fetch(`${basePath}/vms/labels/${encodeURIComponent(label)}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ remove: vmIds }),
-        }).then((res) => {
-          if (!res.ok) {
-            throw new Error(`Failed to remove label "${label}": ${res.status}`);
-          }
+        agentApi.updateLabelVMs({
+          label,
+          updateLabelVMsRequest: { remove: vmIds },
         }),
       );
 
       await Promise.all([...addPromises, ...removePromises]);
       await refreshLabels();
     },
-    [addLabelsVMIds, basePath, refreshLabels],
+    [addLabelsVMIds, agentApi, refreshLabels],
   );
 
   const handleVMClick = (vmId: string) => {
@@ -366,6 +372,11 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
 
   const handleBack = () => {
     setSelectedVMId(null);
+    if (searchParams.has("vmId")) {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.delete("vmId");
+      setSearchParams(newParams, { replace: true });
+    }
   };
 
   const handleRunDeepInspection = (includeVmId?: string) => {
@@ -600,14 +611,14 @@ export const VirtualMachinesView: React.FC<VirtualMachinesViewProps> = ({
         selectedVMName={selectedVMName}
         mode={addLabelsMode}
       />
-      <ManageLabelsModal
-        isOpen={isManageLabelsModalOpen}
-        onClose={() => setIsManageLabelsModalOpen(false)}
-        onLabelsChanged={refreshLabels}
-        basePath={basePath}
-      />
       {agentApi && (
         <>
+          <ManageLabelsModal
+            isOpen={isManageLabelsModalOpen}
+            onClose={() => setIsManageLabelsModalOpen(false)}
+            onLabelsChanged={refreshLabels}
+            agentApi={agentApi}
+          />
           <CreateGroupFromSelectionModal
             isOpen={isCreateGroupModalOpen}
             vmIds={groupActionVMIds}

--- a/apps/agent-ui/src/pages/Report/components/applicationFilters.test.ts
+++ b/apps/agent-ui/src/pages/Report/components/applicationFilters.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterApplications,
+  filterVmsBySearch,
+  getUniqueVms,
+  matchesSearch,
+  paginateItems,
+} from "./applicationFilters";
+import type { ApplicationOverview } from "./applicationsApi";
+
+const applications: ApplicationOverview[] = [
+  {
+    name: "Apache HTTP Server",
+    description: "",
+    vmCount: 1,
+    vms: [{ id: "vm-1", name: "web-01.prod.local" }],
+  },
+  {
+    name: "PostgreSQL",
+    description: "",
+    vmCount: 1,
+    vms: [{ id: "vm-2", name: "db-01.prod.local" }],
+  },
+];
+
+describe("matchesSearch", () => {
+  it("matches case-insensitively", () => {
+    expect(matchesSearch("Apache HTTP Server", "apache")).toBe(true);
+  });
+});
+
+describe("filterApplications", () => {
+  it("filters by application name", () => {
+    expect(
+      filterApplications(applications, { nameSearch: "apache", vmIds: [] }),
+    ).toEqual([applications[0]]);
+  });
+
+  it("filters by selected VM ids", () => {
+    expect(
+      filterApplications(applications, { nameSearch: "", vmIds: ["vm-2"] }),
+    ).toEqual([applications[1]]);
+  });
+
+  it("combines name and VM filters", () => {
+    expect(
+      filterApplications(applications, {
+        nameSearch: "post",
+        vmIds: ["vm-2"],
+      }),
+    ).toEqual([applications[1]]);
+  });
+});
+
+describe("getUniqueVms", () => {
+  it("deduplicates VMs across applications", () => {
+    const shared: ApplicationOverview[] = [
+      {
+        name: "App A",
+        description: "",
+        vmCount: 1,
+        vms: [{ id: "vm-1", name: "shared" }],
+      },
+      {
+        name: "App B",
+        description: "",
+        vmCount: 1,
+        vms: [{ id: "vm-1", name: "shared" }],
+      },
+    ];
+    expect(getUniqueVms(shared)).toEqual([{ id: "vm-1", name: "shared" }]);
+  });
+});
+
+describe("filterVmsBySearch", () => {
+  it("returns all VMs when search is empty", () => {
+    expect(filterVmsBySearch(applications[0].vms, "")).toEqual(
+      applications[0].vms,
+    );
+  });
+
+  it("filters VMs by name", () => {
+    expect(filterVmsBySearch(applications[0].vms, "web-01")).toEqual(
+      applications[0].vms,
+    );
+  });
+});
+
+describe("paginateItems", () => {
+  it("returns the requested page slice", () => {
+    expect(paginateItems([1, 2, 3, 4, 5], 2, 2)).toEqual([3, 4]);
+  });
+});

--- a/apps/agent-ui/src/pages/Report/components/applicationFilters.ts
+++ b/apps/agent-ui/src/pages/Report/components/applicationFilters.ts
@@ -1,0 +1,80 @@
+import type { ApplicationOverview, ApplicationVM } from "./applicationsApi";
+
+export interface ApplicationFilterState {
+  nameSearch: string;
+  vmIds: string[];
+}
+
+export function matchesSearch(value: string, query: string): boolean {
+  return value.toLowerCase().includes(query.trim().toLowerCase());
+}
+
+export function getUniqueVms(
+  applications: ApplicationOverview[],
+): ApplicationVM[] {
+  const vmById = new Map<string, ApplicationVM>();
+  for (const application of applications) {
+    for (const vm of application.vms) {
+      vmById.set(vm.id, vm);
+    }
+  }
+  return Array.from(vmById.values()).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+}
+
+export function buildVmLookup(
+  applications: ApplicationOverview[],
+): Map<string, ApplicationVM> {
+  return new Map(getUniqueVms(applications).map((vm) => [vm.id, vm]));
+}
+
+export function filterApplications(
+  applications: ApplicationOverview[],
+  filters: ApplicationFilterState,
+): ApplicationOverview[] {
+  const selectedVmIds = new Set(filters.vmIds);
+  const nameSearch = filters.nameSearch.trim();
+
+  return applications.filter((application) => {
+    if (nameSearch && !matchesSearch(application.name, nameSearch)) {
+      return false;
+    }
+    if (selectedVmIds.size > 0) {
+      return application.vms.some((vm) => selectedVmIds.has(vm.id));
+    }
+    return true;
+  });
+}
+
+export function filterVmsBySearch(
+  vms: ApplicationVM[],
+  search: string,
+): ApplicationVM[] {
+  if (!search.trim()) {
+    return vms;
+  }
+  return vms.filter((vm) => matchesSearch(vm.name, search));
+}
+
+export function paginateItems<T>(
+  items: T[],
+  page: number,
+  pageSize: number,
+): T[] {
+  const start = (page - 1) * pageSize;
+  return items.slice(start, start + pageSize);
+}
+
+export function getVmFilterLabel(
+  selectedVmIds: string[],
+  vmById: Map<string, ApplicationVM>,
+): string {
+  if (selectedVmIds.length === 0) {
+    return "Filter by Virtual machines";
+  }
+  if (selectedVmIds.length === 1) {
+    return vmById.get(selectedVmIds[0])?.name ?? "1 virtual machine";
+  }
+  return `${selectedVmIds.length} virtual machines`;
+}

--- a/apps/agent-ui/src/pages/Report/components/applicationsApi.test.ts
+++ b/apps/agent-ui/src/pages/Report/components/applicationsApi.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { ApplicationOverview } from "./applicationsApi";
+import { scopeApplicationsToVms } from "./applicationsApi";
+
+const sampleApplications: ApplicationOverview[] = [
+  {
+    name: "Apache HTTP Server",
+    description: "Web server",
+    vmCount: 2,
+    vms: [
+      { id: "vm-1", name: "web-01" },
+      { id: "vm-2", name: "web-02" },
+    ],
+  },
+  {
+    name: "PostgreSQL",
+    description: "Database",
+    vmCount: 2,
+    vms: [
+      { id: "vm-2", name: "web-02" },
+      { id: "vm-3", name: "db-01" },
+    ],
+  },
+  {
+    name: "Nginx",
+    description: "Web server",
+    vmCount: 1,
+    vms: [{ id: "vm-4", name: "edge-01" }],
+  },
+];
+
+describe("scopeApplicationsToVms", () => {
+  it("returns empty list when scope is empty", () => {
+    expect(scopeApplicationsToVms(sampleApplications, new Set())).toEqual([]);
+  });
+
+  it("keeps only VMs in scope and updates vmCount", () => {
+    expect(
+      scopeApplicationsToVms(sampleApplications, new Set(["vm-1"])),
+    ).toEqual([
+      {
+        name: "Apache HTTP Server",
+        description: "Web server",
+        vmCount: 1,
+        vms: [{ id: "vm-1", name: "web-01" }],
+      },
+    ]);
+  });
+
+  it("drops applications with no VMs in scope", () => {
+    expect(
+      scopeApplicationsToVms(sampleApplications, new Set(["vm-1", "vm-3"])),
+    ).toEqual([
+      {
+        name: "Apache HTTP Server",
+        description: "Web server",
+        vmCount: 1,
+        vms: [{ id: "vm-1", name: "web-01" }],
+      },
+      {
+        name: "PostgreSQL",
+        description: "Database",
+        vmCount: 1,
+        vms: [{ id: "vm-3", name: "db-01" }],
+      },
+    ]);
+  });
+});

--- a/apps/agent-ui/src/pages/Report/components/applicationsApi.ts
+++ b/apps/agent-ui/src/pages/Report/components/applicationsApi.ts
@@ -1,0 +1,33 @@
+import type { ApplicationOverview } from "@openshift-migration-advisor/agent-sdk";
+
+export type {
+  ApplicationListResponse,
+  ApplicationOverview,
+  ApplicationVM,
+} from "@openshift-migration-advisor/agent-sdk";
+
+/** Restrict applications to VMs in the given scope (e.g. group membership). */
+export function scopeApplicationsToVms(
+  applications: ApplicationOverview[],
+  scopedVmIds: Set<string>,
+): ApplicationOverview[] {
+  if (scopedVmIds.size === 0) {
+    return [];
+  }
+
+  return applications
+    .map((application) => {
+      const vms = application.vms.filter((vm) => scopedVmIds.has(vm.id));
+      if (vms.length === 0) {
+        return null;
+      }
+      return {
+        ...application,
+        vms,
+        vmCount: vms.length,
+      };
+    })
+    .filter((application): application is ApplicationOverview =>
+      Boolean(application),
+    );
+}

--- a/apps/agent-ui/src/pages/Report/components/index.ts
+++ b/apps/agent-ui/src/pages/Report/components/index.ts
@@ -1,3 +1,4 @@
+export { ApplicationsView } from "./ApplicationsView";
 export { ClustersOverview } from "./ClustersOverview";
 export { CpuAndMemoryOverview } from "./CpuAndMemoryOverview";
 export { Dashboard } from "./Dashboard";

--- a/apps/agent-ui/src/pages/Report/inventoryParsing.ts
+++ b/apps/agent-ui/src/pages/Report/inventoryParsing.ts
@@ -1,10 +1,15 @@
 import type {
+  GetInventory200Response,
   Infra,
   Inventory,
   InventoryData,
   VMs,
 } from "@openshift-migration-advisor/agent-sdk";
-import { InventoryFromJSON } from "@openshift-migration-advisor/agent-sdk";
+import {
+  InventoryFromJSON,
+  instanceOfInventory,
+  instanceOfUpdateInventory,
+} from "@openshift-migration-advisor/agent-sdk";
 
 /** Parse inventory JSON from GET /groups/{id} or GET /inventory. */
 export function parseInventoryFromJson(json: unknown): Inventory | null {
@@ -17,6 +22,25 @@ export function parseInventoryFromJson(json: unknown): Inventory | null {
   }
   if ("vcenter_id" in record && "clusters" in record) {
     return InventoryFromJSON(json);
+  }
+  return null;
+}
+
+/** Extract inventory from GET /inventory SDK response. */
+export function inventoryFromGetInventoryResponse(
+  response: GetInventory200Response | null | undefined,
+): Inventory | null {
+  if (!response || typeof response !== "object") {
+    return null;
+  }
+  if (Object.keys(response).length === 0) {
+    return null;
+  }
+  if (instanceOfInventory(response)) {
+    return response;
+  }
+  if (instanceOfUpdateInventory(response) && response.inventory) {
+    return response.inventory;
   }
   return null;
 }

--- a/apps/agent-ui/src/pages/Report/reportTabNavigation.test.ts
+++ b/apps/agent-ui/src/pages/Report/reportTabNavigation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVmDetailUrl,
+  REPORT_TAB,
+  resolveReportTab,
+} from "./reportTabNavigation";
+
+describe("resolveReportTab", () => {
+  it("returns the applications tab from the URL", () => {
+    expect(
+      resolveReportTab(new URLSearchParams("tab=applications"), false),
+    ).toBe(REPORT_TAB.applications);
+  });
+
+  it("opens the VMs tab when filters are active without a tab param", () => {
+    expect(resolveReportTab(new URLSearchParams("search=web"), true)).toBe(
+      REPORT_TAB.vms,
+    );
+  });
+
+  it("defaults to overview", () => {
+    expect(resolveReportTab(new URLSearchParams(), false)).toBe(
+      REPORT_TAB.overview,
+    );
+  });
+});
+
+describe("buildVmDetailUrl", () => {
+  it("sets tab and vmId while clearing VM filters", () => {
+    const params = buildVmDetailUrl(
+      new URLSearchParams("search=web&tab=applications"),
+      "vm-123",
+    );
+    expect(params.get("tab")).toBe("vms");
+    expect(params.get("vmId")).toBe("vm-123");
+    expect(params.get("search")).toBeNull();
+  });
+});

--- a/apps/agent-ui/src/pages/Report/reportTabNavigation.ts
+++ b/apps/agent-ui/src/pages/Report/reportTabNavigation.ts
@@ -1,0 +1,109 @@
+/** Tab indices for report overview pages (Assessment / VMs / Applications). */
+export const REPORT_TAB = {
+  overview: 0,
+  vms: 1,
+  applications: 2,
+} as const;
+
+export type ReportTabIndex = (typeof REPORT_TAB)[keyof typeof REPORT_TAB];
+
+export function reportTabFromParam(tabParam: string | null): ReportTabIndex {
+  if (tabParam === "vms") {
+    return REPORT_TAB.vms;
+  }
+  if (tabParam === "applications") {
+    return REPORT_TAB.applications;
+  }
+  if (tabParam === "overview") {
+    return REPORT_TAB.overview;
+  }
+  return REPORT_TAB.overview;
+}
+
+/** Resolves the active tab from URL params, including legacy VM-filter behavior. */
+export function resolveReportTab(
+  searchParams: URLSearchParams,
+  hasActiveVmFilters: boolean,
+): ReportTabIndex {
+  const tabParam = searchParams.get("tab");
+  if (tabParam === "vms") {
+    return REPORT_TAB.vms;
+  }
+  if (tabParam === "applications") {
+    return REPORT_TAB.applications;
+  }
+  if (tabParam === "overview") {
+    return REPORT_TAB.overview;
+  }
+  if (!tabParam && hasActiveVmFilters) {
+    return REPORT_TAB.vms;
+  }
+  return REPORT_TAB.overview;
+}
+
+export function reportTabToParam(tabIndex: string | number): string {
+  if (tabIndex === REPORT_TAB.vms) {
+    return "vms";
+  }
+  if (tabIndex === REPORT_TAB.applications) {
+    return "applications";
+  }
+  return "overview";
+}
+
+/** Removes VM-table filter query params (not tab or vmId). */
+export function clearVmFilterParams(params: URLSearchParams): void {
+  params.delete("statuses");
+  params.delete("hasIssues");
+  params.delete("noIssues");
+  params.delete("clusters");
+  params.delete("datacenters");
+  params.delete("search");
+  params.delete("diskRangeMin");
+  params.delete("diskRangeMax");
+  params.delete("memoryRangeMin");
+  params.delete("memoryRangeMax");
+  params.delete("migrationReadiness");
+  params.delete("vmLabels");
+  params.delete("concernLabels");
+  params.delete("concernCategories");
+}
+
+export function buildVmDetailUrl(
+  searchParams: URLSearchParams,
+  vmId: string,
+): URLSearchParams {
+  const params = new URLSearchParams(searchParams);
+  clearVmFilterParams(params);
+  params.set("tab", "vms");
+  params.set("vmId", vmId);
+  return params;
+}
+
+export function buildApplicationsTabUrl(
+  searchParams: URLSearchParams,
+): URLSearchParams {
+  const params = new URLSearchParams(searchParams);
+  clearVmFilterParams(params);
+  params.delete("vmId");
+  params.set("tab", "applications");
+  return params;
+}
+
+export function buildVmsTabUrl(searchParams: URLSearchParams): URLSearchParams {
+  const params = new URLSearchParams(searchParams);
+  clearVmFilterParams(params);
+  params.delete("vmId");
+  params.set("tab", "vms");
+  return params;
+}
+
+export function buildOverviewTabUrl(
+  searchParams: URLSearchParams,
+): URLSearchParams {
+  const params = new URLSearchParams(searchParams);
+  clearVmFilterParams(params);
+  params.delete("vmId");
+  params.set("tab", "overview");
+  return params;
+}

--- a/apps/agent-ui/src/pages/Report/useApplicationsData.ts
+++ b/apps/agent-ui/src/pages/Report/useApplicationsData.ts
@@ -1,0 +1,73 @@
+import type {
+  ApplicationOverview,
+  DefaultApiInterface,
+} from "@openshift-migration-advisor/agent-sdk";
+import { useEffect, useState } from "react";
+import { scopeApplicationsToVms } from "./components/applicationsApi";
+import { fetchAllMatchingVmIds } from "./components/vmSelection";
+
+interface UseApplicationsDataResult {
+  applications: ApplicationOverview[];
+  loading: boolean;
+  error: string | null;
+}
+
+/** Loads applications when the tab is active; optionally scopes to a VM filter expression. */
+export function useApplicationsData(
+  agentApi: DefaultApiInterface,
+  active: boolean,
+  scopeExpression?: string,
+): UseApplicationsDataResult {
+  const [applications, setApplications] = useState<ApplicationOverview[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await agentApi.getApplications();
+        const data = response.applications ?? [];
+
+        let scoped = data;
+        if (scopeExpression) {
+          const vmIds = await fetchAllMatchingVmIds(agentApi, {
+            byExpression: scopeExpression,
+          });
+          scoped = scopeApplicationsToVms(data, new Set(vmIds));
+        }
+
+        if (!cancelled) {
+          setApplications(scoped);
+        }
+      } catch (err) {
+        console.error("Error fetching applications:", err);
+        if (!cancelled) {
+          setApplications([]);
+          setError(
+            err instanceof Error ? err.message : "Failed to load applications.",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [active, agentApi, scopeExpression]);
+
+  return { applications, loading, error };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,7 +564,7 @@ __metadata:
   dependencies:
     "@emotion/css": "npm:^11.13.0"
     "@migration-planner-ui/ioc": "workspace:*"
-    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-b4cc95d9b3d0"
+    "@openshift-migration-advisor/agent-sdk": "npm:0.12.0-e4c04f972747"
     "@patternfly/react-charts": "npm:^8.0.0"
     "@patternfly/react-core": "npm:^6.4.3"
     "@patternfly/react-icons": "npm:^6.4.0"
@@ -607,10 +607,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openshift-migration-advisor/agent-sdk@npm:0.12.0-b4cc95d9b3d0":
-  version: 0.12.0-b4cc95d9b3d0
-  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-b4cc95d9b3d0"
-  checksum: 10c0/3d7b4d80cc76a89c14cd9f53e16dc5d5084ea6adaf423d778e35af0fe273461f906ce2955f8831087b195e8059612ebd98071947db8452326892a5dc17d8d90c
+"@openshift-migration-advisor/agent-sdk@npm:0.12.0-e4c04f972747":
+  version: 0.12.0-e4c04f972747
+  resolution: "@openshift-migration-advisor/agent-sdk@npm:0.12.0-e4c04f972747"
+  checksum: 10c0/539bbdf66d7a930418c0b6b513fc0ce0c23e9f0adeab457654b98a623692f9d2b98c561a9d63f11c8c9618fc3f14fce7753683935fa69ea5ad6e5c93b93af2fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Implemented the Applications tab in the agent UI with:
- Search by application name
- “Filter by Virtual machines” multi-select dropdown
- Filter chips + “Clear all filters”
- Table: Application name | VMs (clickable count)
- Inline drawer: “VMs with {app}” with VM search and empty state
- VM links navigate to the VM detail view

[recording - 2026-06-09T160617.386.webm](https://github.com/user-attachments/assets/d64f34b5-d7c2-4ceb-945d-4942d00da0f1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Applications tab to Report pages with search and filtering capabilities
  * Applications can be filtered by name and selected virtual machines
  * Added side panel to view virtual machines associated with each application

* **Improvements**
  * Enhanced tab navigation and URL parameter synchronization
  * Improved label management and virtual machine filtering
  * Better error handling and loading states across reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->