### PR TITLE
NO-JIRA | fix: add technology preview badge to applications feature

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/ApplicationsView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ApplicationsView.tsx
@@ -16,6 +16,8 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
+  Flex,
+  FlexItem,
   Label,
   LabelGroup,
   MenuToggle,
@@ -41,6 +43,7 @@ import {
   paginateItems,
 } from "./applicationFilters";
 import type { ApplicationOverview } from "./applicationsApi";
+import { TechnologyPreviewBadge } from "./TechnologyPreviewBadge";
 
 const styles = {
   drawerPanel: css`
@@ -55,6 +58,9 @@ const styles = {
     margin-bottom: 16px;
   `,
   appliedFilters: css`
+    margin-bottom: 16px;
+  `,
+  header: css`
     margin-bottom: 16px;
   `,
   vmFilterMenu: css`
@@ -223,6 +229,21 @@ export const ApplicationsView: React.FC<ApplicationsViewProps> = ({
     <Drawer isExpanded={drawerApplication !== null} isInline position="end">
       <DrawerContent panelContent={panelContent}>
         <DrawerContentBody>
+          <Flex
+            className={styles.header}
+            alignItems={{ default: "alignItemsCenter" }}
+            spaceItems={{ default: "spaceItemsSm" }}
+          >
+            <FlexItem>
+              <Title headingLevel="h2" size="lg">
+                Applications
+              </Title>
+            </FlexItem>
+            <FlexItem>
+              <TechnologyPreviewBadge />
+            </FlexItem>
+          </Flex>
+
           {error && (
             <Alert
               variant="danger"


### PR DESCRIPTION
<img width="1113" height="421" alt="image" src="https://github.com/user-attachments/assets/69c82817-c6ff-42ec-b7e3-3cc60e7ba531" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Applications view now displays a new header section featuring the page title and a technology preview indicator badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->