### PR TITLE
ECOPROJECT-4761 | fix: Fix Assessment Report VM counts after exclude/include VMs

### DIFF
--- a/apps/agent-ui/src/pages/Report/GroupDetailPage.tsx
+++ b/apps/agent-ui/src/pages/Report/GroupDetailPage.tsx
@@ -37,7 +37,6 @@ import {
 } from "react-router-dom";
 import { useAgentStatus } from "../../common/AgentStatusContext";
 import { Symbols } from "../../main/Symbols";
-import { getAgentApiBasePath } from "./agentApiConfig";
 import { buildClusterViewModel, type ClusterOption } from "./clusterView";
 import { ApplicationsView, Dashboard, VirtualMachinesView } from "./components";
 import { DeleteGroupModal } from "./components/DeleteGroupModal";
@@ -51,14 +50,7 @@ import {
   type VMFilters,
 } from "./components/vmFilters";
 import { Header } from "./Header";
-import {
-  adjustInventoryForMigrationExcludedChange,
-  fetchInventoryAfterMigrationChange,
-  fetchInventoryFromApi,
-  getInventoryAggregateView,
-  type MigrationExcludedInventoryChange,
-  resolveInventoryOnReload,
-} from "./inventoryParsing";
+import { getInventoryAggregateView } from "./inventoryParsing";
 import {
   buildApplicationsTabUrl,
   buildOverviewTabUrl,
@@ -69,6 +61,7 @@ import {
   resolveReportTab,
 } from "./reportTabNavigation";
 import { useApplicationsData } from "./useApplicationsData";
+import { useMigrationInventoryRefresh } from "./useMigrationInventoryRefresh";
 import { normalizeVirtualMachines } from "./virtualMachineParsing";
 
 export const GroupDetailPage: React.FC = () => {
@@ -95,6 +88,7 @@ export const GroupDetailPage: React.FC = () => {
   const [vmsPageSize, setVmsPageSize] = useState(20);
   const [vmsSortFields, setVmsSortFields] = useState<string[]>([]);
   const [showExcludedVMs, setShowExcludedVMs] = useState(true);
+  const [inventoryRevision, setInventoryRevision] = useState(0);
   const [availableFilterOptions, setAvailableFilterOptions] = useState({
     clusters: [] as string[],
     datacenters: [] as string[],
@@ -311,86 +305,18 @@ export const GroupDetailPage: React.FC = () => {
     vmsPageSize,
   ]);
 
-  const reloadAssessmentInventory = useCallback(async () => {
-    if (!groupId) {
-      return;
-    }
+  const bumpInventoryRevision = useCallback(() => {
+    setInventoryRevision((revision) => revision + 1);
+  }, []);
 
-    try {
-      const basePath = getAgentApiBasePath(agentApi);
-      const fetchedInventory = await fetchInventoryFromApi(basePath, {
-        groupId,
-      });
-      if (!fetchedInventory) {
-        return;
-      }
-
-      setInventory((current) => {
-        if (!current) {
-          return fetchedInventory;
-        }
-
-        return resolveInventoryOnReload(current, fetchedInventory);
-      });
-    } catch (err) {
-      console.error("Error reloading group assessment inventory:", err);
-    }
-  }, [agentApi, groupId]);
-
-  const refreshGroupInventory = useCallback(
-    async (change: MigrationExcludedInventoryChange): Promise<void> => {
-      if (!groupId) {
-        return;
-      }
-
-      setVmsList((current) =>
-        current.map((vm) =>
-          change.vmIds.includes(vm.id)
-            ? { ...vm, migrationExcluded: change.excluded }
-            : vm,
-        ),
-      );
-
-      let previousTotal: number | undefined;
-      let optimisticInventory: Inventory | null = null;
-
-      setInventory((current) => {
-        if (!current) {
-          return current;
-        }
-        previousTotal = getInventoryAggregateView(current).vms?.total;
-        optimisticInventory = adjustInventoryForMigrationExcludedChange(
-          current,
-          change.vmIds,
-          change.excluded,
-          change.affectedVms,
-        );
-        return optimisticInventory;
-      });
-
-      try {
-        const basePath = getAgentApiBasePath(agentApi);
-        const resolved = await fetchInventoryAfterMigrationChange(
-          basePath,
-          change,
-          previousTotal,
-          optimisticInventory,
-          { groupId },
-        );
-        if (resolved) {
-          setInventory((current) => {
-            if (!current) {
-              return resolved;
-            }
-            return resolveInventoryOnReload(current, resolved);
-          });
-        }
-      } catch (err) {
-        console.error("Error refreshing group inventory:", err);
-      }
-    },
-    [agentApi, groupId],
-  );
+  const { refreshInventory: refreshGroupInventory, reloadAssessmentInventory } =
+    useMigrationInventoryRefresh({
+      agentApi,
+      groupId,
+      setInventory,
+      setVmsList,
+      onInventoryRevisionBump: bumpInventoryRevision,
+    });
 
   const reloadGroupMembership = useCallback(async () => {
     if (!groupId) {
@@ -638,7 +564,7 @@ export const GroupDetailPage: React.FC = () => {
                 {clusterView.viewInfra && clusterView.viewVms ? (
                   <div style={{ marginTop: "24px" }}>
                     <Dashboard
-                      key={`group-assessment-${clusterView.viewVms.total ?? 0}-${clusterView.selectionId}`}
+                      key={`group-assessment-${inventoryRevision}-${clusterView.viewVms.total ?? 0}-${clusterView.selectionId}`}
                       infra={clusterView.viewInfra}
                       cpuCores={clusterView.cpuCores}
                       ramGB={clusterView.ramGB}

--- a/apps/agent-ui/src/pages/Report/ReportContainer.tsx
+++ b/apps/agent-ui/src/pages/Report/ReportContainer.tsx
@@ -51,12 +51,8 @@ import {
 } from "./components/vmFilters";
 import { Header } from "./Header";
 import {
-  adjustInventoryForMigrationExcludedChange,
-  fetchInventoryAfterMigrationChange,
   fetchInventoryFromApi,
   getInventoryAggregateView,
-  type MigrationExcludedInventoryChange,
-  resolveInventoryOnReload,
 } from "./inventoryParsing";
 import {
   buildApplicationsTabUrl,
@@ -68,6 +64,7 @@ import {
   resolveReportTab,
 } from "./reportTabNavigation";
 import { useApplicationsData } from "./useApplicationsData";
+import { useMigrationInventoryRefresh } from "./useMigrationInventoryRefresh";
 import { normalizeVirtualMachines } from "./virtualMachineParsing";
 
 export const ReportContainer: React.FC = () => {
@@ -159,79 +156,17 @@ export const ReportContainer: React.FC = () => {
     return fetchInventoryFromApi(basePath);
   }, [agentApi]);
 
-  const reloadAssessmentInventory = useCallback(async () => {
-    try {
-      const fetchedInventory = await fetchInventory();
-      if (!fetchedInventory) {
-        return;
-      }
+  const bumpInventoryRevision = useCallback(() => {
+    setInventoryRevision((revision) => revision + 1);
+  }, []);
 
-      setInventory((current) => {
-        if (!current) {
-          return fetchedInventory;
-        }
-
-        return resolveInventoryOnReload(current, fetchedInventory);
-      });
-    } catch (err) {
-      console.error("Error reloading assessment inventory:", err);
-    }
-  }, [fetchInventory]);
-
-  const refreshInventory = useCallback(
-    async (change: MigrationExcludedInventoryChange): Promise<void> => {
-      setVmsList((current) =>
-        current.map((vm) =>
-          change.vmIds.includes(vm.id)
-            ? { ...vm, migrationExcluded: change.excluded }
-            : vm,
-        ),
-      );
-
-      let previousTotal: number | undefined;
-      let optimisticInventory: Inventory | null = null;
-
-      setInventory((current) => {
-        if (!current) {
-          return current;
-        }
-        previousTotal = getInventoryAggregateView(current).vms?.total;
-        optimisticInventory = adjustInventoryForMigrationExcludedChange(
-          current,
-          change.vmIds,
-          change.excluded,
-          change.affectedVms,
-        );
-        return optimisticInventory;
-      });
-
-      if (optimisticInventory) {
-        setInventoryRevision((revision) => revision + 1);
-      }
-
-      try {
-        const basePath = getAgentApiBasePath(agentApi);
-        const resolved = await fetchInventoryAfterMigrationChange(
-          basePath,
-          change,
-          previousTotal,
-          optimisticInventory,
-        );
-        if (resolved) {
-          setInventory((current) => {
-            if (!current) {
-              return resolved;
-            }
-            return resolveInventoryOnReload(current, resolved);
-          });
-          setInventoryRevision((revision) => revision + 1);
-        }
-      } catch (err) {
-        console.error("Error refreshing inventory:", err);
-      }
-    },
-    [agentApi],
-  );
+  const { refreshInventory, reloadAssessmentInventory } =
+    useMigrationInventoryRefresh({
+      agentApi,
+      setInventory,
+      setVmsList,
+      onInventoryRevisionBump: bumpInventoryRevision,
+    });
 
   // Fetch inventory only (agent status comes from context)
   useEffect(() => {

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -54,7 +54,24 @@ async function updateVmMigrationExcluded(
   }
 
   const successfulIds = vmIds.filter((id) => !failedIds.includes(id));
-  const affectedVms = knownVms.filter((vm) => successfulIds.includes(vm.id));
+  // Use pre-change exclusion state so bulk exclude/include stays accurate even if
+  // the table list has not refreshed yet from a prior operation.
+  const affectedVms = successfulIds.map((id) => {
+    const vm = knownVms.find((candidate) => candidate.id === id);
+    return {
+      ...(vm ?? {
+        id,
+        name: id,
+        vCenterState: "",
+        cluster: "",
+        datacenter: "",
+        diskSize: 0,
+        memory: 0,
+        issueCount: 0,
+      }),
+      migrationExcluded: !migrationExcluded,
+    };
+  });
 
   if (successfulIds.length > 0) {
     await onRefreshInventory?.({

--- a/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/VirtualMachinesView.tsx
@@ -68,6 +68,7 @@ async function updateVmMigrationExcluded(
         diskSize: 0,
         memory: 0,
         issueCount: 0,
+        migratable: false,
       }),
       migrationExcluded: !migrationExcluded,
     };

--- a/apps/agent-ui/src/pages/Report/inventoryParsing.test.ts
+++ b/apps/agent-ui/src/pages/Report/inventoryParsing.test.ts
@@ -120,6 +120,55 @@ describe("getInventoryAggregateView", () => {
   });
 });
 
+describe("sequential migration excluded changes", () => {
+  it("restores totals after exclude then include", () => {
+    let inventory = baseInventory;
+    inventory = adjustInventoryForMigrationExcludedChange(
+      inventory,
+      ["vm-1"],
+      true,
+      [vm],
+    );
+    inventory = adjustInventoryForMigrationExcludedChange(
+      inventory,
+      ["vm-1"],
+      false,
+      [{ ...vm, migrationExcluded: true }],
+    );
+
+    expect(getInventoryAggregateView(inventory).vms?.total).toBe(2);
+  });
+
+  it("applies bulk exclude then bulk include", () => {
+    const vm2: VirtualMachine = { ...vm, id: "vm-2", name: "web-2" };
+    const inventoryWithTwo: Inventory = {
+      ...baseInventory,
+      vcenter: {
+        infra: testInfra(1),
+        vms: testVms(2, 2),
+      },
+    };
+
+    let inventory = adjustInventoryForMigrationExcludedChange(
+      inventoryWithTwo,
+      ["vm-1", "vm-2"],
+      true,
+      [vm, vm2],
+    );
+    inventory = adjustInventoryForMigrationExcludedChange(
+      inventory,
+      ["vm-1", "vm-2"],
+      false,
+      [
+        { ...vm, migrationExcluded: true },
+        { ...vm2, migrationExcluded: true },
+      ],
+    );
+
+    expect(getInventoryAggregateView(inventory).vms?.total).toBe(2);
+  });
+});
+
 describe("resolveInventoryAfterMigrationChange", () => {
   it("keeps optimistic inventory when server response is stale", () => {
     const optimistic = adjustInventoryForMigrationExcludedChange(

--- a/apps/agent-ui/src/pages/Report/inventoryParsing.ts
+++ b/apps/agent-ui/src/pages/Report/inventoryParsing.ts
@@ -334,23 +334,6 @@ export async function fetchInventoryAfterMigrationChange(
   return optimisticInventory;
 }
 
-/** Keep optimistic totals when reloading inventory before the server catches up. */
-export function resolveInventoryOnReload(
-  currentInventory: Inventory,
-  fetchedInventory: Inventory,
-): Inventory {
-  const currentTotal = getInventoryAggregateView(currentInventory).vms?.total;
-  const fetchedTotal = getInventoryAggregateView(fetchedInventory).vms?.total;
-  if (
-    currentTotal !== undefined &&
-    fetchedTotal !== undefined &&
-    fetchedTotal !== currentTotal
-  ) {
-    return currentInventory;
-  }
-  return fetchedInventory;
-}
-
 export type InventoryAggregateView = {
   infra?: Infra;
   vms?: VMs;

--- a/apps/agent-ui/src/pages/Report/useMigrationInventoryRefresh.ts
+++ b/apps/agent-ui/src/pages/Report/useMigrationInventoryRefresh.ts
@@ -1,0 +1,124 @@
+import type {
+  DefaultApiInterface,
+  Inventory,
+  VirtualMachine,
+} from "@openshift-migration-advisor/agent-sdk";
+import { useCallback, useRef } from "react";
+import { getAgentApiBasePath } from "./agentApiConfig";
+import {
+  adjustInventoryForMigrationExcludedChange,
+  fetchInventoryAfterMigrationChange,
+  fetchInventoryFromApi,
+  getInventoryAggregateView,
+  type MigrationExcludedInventoryChange,
+} from "./inventoryParsing";
+
+type UseMigrationInventoryRefreshOptions = {
+  agentApi: DefaultApiInterface;
+  groupId?: string;
+  setInventory: React.Dispatch<React.SetStateAction<Inventory | null>>;
+  setVmsList: React.Dispatch<React.SetStateAction<VirtualMachine[]>>;
+  onInventoryRevisionBump?: () => void;
+};
+
+function createSerialQueue() {
+  let chain: Promise<void> = Promise.resolve();
+
+  return <T>(task: () => Promise<T>): Promise<T> => {
+    const next = chain.then(task, task);
+    chain = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  };
+}
+
+export function useMigrationInventoryRefresh({
+  agentApi,
+  groupId,
+  setInventory,
+  setVmsList,
+  onInventoryRevisionBump,
+}: UseMigrationInventoryRefreshOptions) {
+  const enqueueRef = useRef(createSerialQueue());
+  const pendingMigrationUpdatesRef = useRef(0);
+
+  const refreshInventory = useCallback(
+    async (change: MigrationExcludedInventoryChange): Promise<void> => {
+      pendingMigrationUpdatesRef.current += 1;
+
+      try {
+        await enqueueRef.current(async () => {
+          setVmsList((current) =>
+            current.map((vm) =>
+              change.vmIds.includes(vm.id)
+                ? { ...vm, migrationExcluded: change.excluded }
+                : vm,
+            ),
+          );
+
+          let previousTotal: number | undefined;
+          let optimisticInventory: Inventory | null = null;
+
+          setInventory((current) => {
+            if (!current) {
+              return current;
+            }
+            previousTotal = getInventoryAggregateView(current).vms?.total;
+            optimisticInventory = adjustInventoryForMigrationExcludedChange(
+              current,
+              change.vmIds,
+              change.excluded,
+              change.affectedVms,
+            );
+            return optimisticInventory;
+          });
+
+          if (optimisticInventory) {
+            onInventoryRevisionBump?.();
+          }
+
+          const basePath = getAgentApiBasePath(agentApi);
+          const resolved = await fetchInventoryAfterMigrationChange(
+            basePath,
+            change,
+            previousTotal,
+            optimisticInventory,
+            groupId ? { groupId } : undefined,
+          );
+
+          if (resolved) {
+            setInventory(resolved);
+            onInventoryRevisionBump?.();
+          }
+        });
+      } finally {
+        pendingMigrationUpdatesRef.current -= 1;
+      }
+    },
+    [agentApi, groupId, onInventoryRevisionBump, setInventory, setVmsList],
+  );
+
+  const reloadAssessmentInventory = useCallback(async () => {
+    if (pendingMigrationUpdatesRef.current > 0) {
+      return;
+    }
+
+    try {
+      const basePath = getAgentApiBasePath(agentApi);
+      const fetchedInventory = await fetchInventoryFromApi(
+        basePath,
+        groupId ? { groupId } : undefined,
+      );
+      if (fetchedInventory) {
+        setInventory(fetchedInventory);
+        onInventoryRevisionBump?.();
+      }
+    } catch (err) {
+      console.error("Error reloading assessment inventory:", err);
+    }
+  }, [agentApi, groupId, onInventoryRevisionBump, setInventory]);
+
+  return { refreshInventory, reloadAssessmentInventory };
+}

--- a/apps/agent-ui/src/pages/Report/useMigrationInventoryRefresh.ts
+++ b/apps/agent-ui/src/pages/Report/useMigrationInventoryRefresh.ts
@@ -50,47 +50,54 @@ export function useMigrationInventoryRefresh({
 
       try {
         await enqueueRef.current(async () => {
-          setVmsList((current) =>
-            current.map((vm) =>
-              change.vmIds.includes(vm.id)
-                ? { ...vm, migrationExcluded: change.excluded }
-                : vm,
-            ),
-          );
-
-          let previousTotal: number | undefined;
-          let optimisticInventory: Inventory | null = null;
-
-          setInventory((current) => {
-            if (!current) {
-              return current;
-            }
-            previousTotal = getInventoryAggregateView(current).vms?.total;
-            optimisticInventory = adjustInventoryForMigrationExcludedChange(
-              current,
-              change.vmIds,
-              change.excluded,
-              change.affectedVms,
+          try {
+            setVmsList((current) =>
+              current.map((vm) =>
+                change.vmIds.includes(vm.id)
+                  ? { ...vm, migrationExcluded: change.excluded }
+                  : vm,
+              ),
             );
-            return optimisticInventory;
-          });
 
-          if (optimisticInventory) {
-            onInventoryRevisionBump?.();
-          }
+            let previousTotal: number | undefined;
+            let optimisticInventory: Inventory | null = null;
 
-          const basePath = getAgentApiBasePath(agentApi);
-          const resolved = await fetchInventoryAfterMigrationChange(
-            basePath,
-            change,
-            previousTotal,
-            optimisticInventory,
-            groupId ? { groupId } : undefined,
-          );
+            setInventory((current) => {
+              if (!current) {
+                return current;
+              }
+              previousTotal = getInventoryAggregateView(current).vms?.total;
+              optimisticInventory = adjustInventoryForMigrationExcludedChange(
+                current,
+                change.vmIds,
+                change.excluded,
+                change.affectedVms,
+              );
+              return optimisticInventory;
+            });
 
-          if (resolved) {
-            setInventory(resolved);
-            onInventoryRevisionBump?.();
+            if (optimisticInventory) {
+              onInventoryRevisionBump?.();
+            }
+
+            const basePath = getAgentApiBasePath(agentApi);
+            const resolved = await fetchInventoryAfterMigrationChange(
+              basePath,
+              change,
+              previousTotal,
+              optimisticInventory,
+              groupId ? { groupId } : undefined,
+            );
+
+            if (resolved) {
+              setInventory((current) => resolved ?? current);
+              onInventoryRevisionBump?.();
+            }
+          } catch (err) {
+            console.error(
+              "Error refreshing inventory after migration change:",
+              err,
+            );
           }
         });
       } finally {


### PR DESCRIPTION

- Refresh and optimistically update inventory when VMs are excluded or included from reports, so the Assessment Report tab stays in sync with the Virtual Machines tab without a page reload.
- Serialize inventory updates to avoid race conditions during bulk exclude/include, prefer vcenter VM totals for the main report aggregate, normalize migration_excluded from the API, and add tests for sequential inventory adjustments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of inventory totals when excluding or including virtual machines from migration operations.
  * Enhanced reliability of bulk VM exclusion and inclusion workflows to ensure inventory reflects state changes correctly.

* **Tests**
  * Added comprehensive test coverage for sequential VM migration exclusion and inclusion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->