### PR TITLE
ECOPROJECT-4787 | fix: search input by application name was cutted

### DIFF
--- a/apps/agent-ui/src/pages/Report/components/ApplicationsView.tsx
+++ b/apps/agent-ui/src/pages/Report/components/ApplicationsView.tsx
@@ -57,6 +57,13 @@ const styles = {
   toolbar: css`
     margin-bottom: 16px;
   `,
+  nameSearchToolbarItem: css`
+    flex: 1;
+    min-width: 200px;
+  `,
+  nameSearchInput: css`
+    width: 100%;
+  `,
   appliedFilters: css`
     margin-bottom: 16px;
   `,
@@ -257,8 +264,9 @@ export const ApplicationsView: React.FC<ApplicationsViewProps> = ({
           <Toolbar className={styles.toolbar}>
             <ToolbarContent>
               <ToolbarGroup variant="filter-group">
-                <ToolbarItem>
+                <ToolbarItem className={styles.nameSearchToolbarItem}>
                   <SearchInput
+                    className={styles.nameSearchInput}
                     placeholder="Find by application name"
                     value={nameSearch}
                     onChange={(_event, value) => applyNameSearch(value)}


### PR DESCRIPTION
Before changes:
<img width="228" height="122" alt="image" src="https://github.com/user-attachments/assets/e83981a0-66f9-480c-bb62-3f50c99699df" />


After changes:
<img width="732" height="189" alt="image" src="https://github.com/user-attachments/assets/080ef2ea-1c1f-424d-a705-2043e2f0e354" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the width of the application name search input field in the main toolbar to improve visibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->